### PR TITLE
List-style margin fix

### DIFF
--- a/tenants/ecmweb/components/blocks/list-section-wrapper.marko
+++ b/tenants/ecmweb/components/blocks/list-section-wrapper.marko
@@ -15,8 +15,8 @@ $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helveti
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
 $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
   "font-weight": "bold",
-  "color": "#014750",
-  "font-size": "19.5px",
+  "color": "#00b398",
+  "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 });
@@ -35,7 +35,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
         <common-table width="700" style=`${mainTableStyle}` align="left" class="main" padding=0 spacing=0>
           <tr>
             <td>
-              <common-table width="100%" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #014750; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #014750;" align="center" class="main" padding=0 spacing=0>
+              <common-table width="100%" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;" align="center" class="main" padding=0 spacing=0>
                 <tr>
                   <td>
                     <h3 style=`${titleStyle}`>${title}</h3>
@@ -54,7 +54,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>
-                <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                <marko-core-obj-text obj=node field="name" attrs={ style: { "margin": "10px 20px", "text-align": "left" } } >
                   <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                 </marko-core-obj-text>
               </for>

--- a/tenants/tdworld/components/blocks/list-section-wrapper.marko
+++ b/tenants/tdworld/components/blocks/list-section-wrapper.marko
@@ -16,7 +16,7 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
 $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
   "font-weight": "bold",
   "color": "#00b398",
-  "font-size": "19.5px",
+  "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 });
@@ -54,7 +54,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>
-                <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                <marko-core-obj-text obj=node field="name" attrs={ style: { "margin": "10px 20px", "text-align": "left" } } >
                   <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                 </marko-core-obj-text>
               </for>

--- a/tenants/tdworld/templates/grid-innovations.marko
+++ b/tenants/tdworld/templates/grid-innovations.marko
@@ -48,7 +48,7 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=68413 date=date newsletter=newsletter title="Trending" />
+    <tenant-list-section-wrapper-block section-id=68413 date=date newsletter=newsletter title="Trending" />
 
     <tenant-section-spacer-block />
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12496550/70176106-7f525480-169d-11ea-9ee7-cba4b0688ac3.png)

I know it still looks inconsistently spaced, it bothers me too.  But I matched their existing style:
![image](https://user-images.githubusercontent.com/12496550/70176135-88dbbc80-169d-11ea-8182-2f8fe2750b0b.png)
