### PR TITLE
Additional EC&M Templates + button-style override

### DIFF
--- a/tenants/ecmweb/components/blocks/card-section-wrapper.marko
+++ b/tenants/ecmweb/components/blocks/card-section-wrapper.marko
@@ -12,8 +12,9 @@ $ const {
   limit
 } = input;
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
+$ const buttonStyle = defaultValue(input.buttonStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #014750;");
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
-$ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
   "font-weight": "bold",
   "color": "#014750",
   "font-size": "19.5px",
@@ -62,7 +63,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle = {
                     <tenant-simple-card-full-block node=node alignment=alignment content-link-style=contentLinkStyle />
                   </if>
                   <else>
-                    <tenant-simple-card-block node=node alignment=alignment content-link-style=contentLinkStyle />
+                    <tenant-simple-card-block node=node alignment=alignment button-style=buttonStyle content-link-style=contentLinkStyle />
                   </else>
                 </else>
                 <if(showDivider(nodes, index))>

--- a/tenants/ecmweb/components/blocks/marko.json
+++ b/tenants/ecmweb/components/blocks/marko.json
@@ -35,6 +35,7 @@
       "default-value": 24
     },
     "@title": "string",
+    "@button-style": "string",
     "@title-style": "string",
     "@main-table-style": "string",
     "@content-link-style": "object"

--- a/tenants/ecmweb/templates/code-watch.marko
+++ b/tenants/ecmweb/templates/code-watch.marko
@@ -36,55 +36,43 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72960 date=date newsletter=newsletter title="Special Report" />
+    <tenant-card-section-wrapper-block section-id=72949 date=date newsletter=newsletter title="Special Report" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72961 date=date newsletter=newsletter title="Web Exclusive" />
+    <tenant-card-section-wrapper-block section-id=72950 date=date newsletter=newsletter title="Moving Violations" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72962 date=date newsletter=newsletter title="Top Story" />
+    <tenant-card-section-wrapper-block section-id=72951 date=date newsletter=newsletter title="Code Violations" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72963 date=date newsletter=newsletter title="Around the Circuit" />
+    <tenant-card-section-wrapper-block section-id=72952 date=date newsletter=newsletter title="Code Quandaries" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72964 date=date newsletter=newsletter title="Code Quiz of the Week" />
+    <tenant-card-section-wrapper-block section-id=72953 date=date newsletter=newsletter title="Code Challenge" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72965 date=date newsletter=newsletter title="Safety Sense" />
+    <tenant-card-section-wrapper-block section-id=72954 date=date newsletter=newsletter title="Web Exclusive" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72966 date=date newsletter=newsletter title="Eye on Safety" />
+    <tenant-card-section-wrapper-block section-id=72956 date=date newsletter=newsletter title="Code Quiz of the Week" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72967 date=date newsletter=newsletter title="Basic Training" />
+    <tenant-card-section-wrapper-block section-id=72957 date=date newsletter=newsletter title="Code Extra" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72968 date=date newsletter=newsletter title="Lighting & Control" />
+    <tenant-card-section-wrapper-block section-id=72958 date=date newsletter=newsletter title="Code Basics" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72969 date=date newsletter=newsletter title="Mergers & Acquisitions" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72970 date=date newsletter=newsletter title="NEC" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72971 date=date newsletter=newsletter title="Case Study" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72972 date=date newsletter=newsletter title="In Case You Missed It" />
+    <tenant-card-section-wrapper-block section-id=72959 date=date newsletter=newsletter title="In Case You Missed It" />
 
     <tenant-section-spacer-block />
 

--- a/tenants/ecmweb/templates/lightfair-show-coverage.marko
+++ b/tenants/ecmweb/templates/lightfair-show-coverage.marko
@@ -1,0 +1,66 @@
+import emailX from "../config/email-x";
+
+$ const { newsletter, date } = data;
+$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
+$ const contentLinkStyle = {
+  "font-weight": "bold",
+  "color": "#00897a",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+};
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #00897a;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <tenant-styles />
+  </@head>
+  <@body style="margin: 0px !important; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+    <tenant-header-block date=date newsletter=newsletter />
+
+    <!-- <tenant-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table> -->
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72985 date=date newsletter=newsletter button-style=buttonStyle content-link-style=contentLinkStyle title="From the Show Floor" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72986 date=date newsletter=newsletter button-style=buttonStyle content-link-style=contentLinkStyle title="Event Recap" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72987 date=date newsletter=newsletter button-style=buttonStyle content-link-style=contentLinkStyle title="New Product Debuts" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72988 date=date newsletter=newsletter button-style=buttonStyle content-link-style=contentLinkStyle title="Awards" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-opt-out-block />
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/ecmweb/templates/mro-insider.marko
+++ b/tenants/ecmweb/templates/mro-insider.marko
@@ -18,7 +18,11 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <!-- <tenant-section-spacer-block />
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72989 date=date newsletter=newsletter title="Maintenance" />
+
+    <tenant-section-spacer-block />
 
     <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
       <tr>
@@ -32,59 +36,43 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
           </marko-newsletters-email-x-display>
         </td>
       </tr>
-    </common-table> -->
+    </common-table>
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72960 date=date newsletter=newsletter title="Special Report" />
+    <tenant-card-section-wrapper-block section-id=72990 date=date newsletter=newsletter title="Repair" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72961 date=date newsletter=newsletter title="Web Exclusive" />
+    <tenant-card-section-wrapper-block section-id=72991 date=date newsletter=newsletter title="Operations" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72962 date=date newsletter=newsletter title="Top Story" />
+    <tenant-card-section-wrapper-block section-id=72992 date=date newsletter=newsletter title="Design" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72963 date=date newsletter=newsletter title="Around the Circuit" />
+    <tenant-card-section-wrapper-block section-id=72993 date=date newsletter=newsletter title="Special Report" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72964 date=date newsletter=newsletter title="Code Quiz of the Week" />
+    <tenant-card-section-wrapper-block section-id=72994 date=date newsletter=newsletter title="Web Exclusive" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72965 date=date newsletter=newsletter title="Safety Sense" />
+    <tenant-card-section-wrapper-block section-id=72995 date=date newsletter=newsletter title="Around the Circuit" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72966 date=date newsletter=newsletter title="Eye on Safety" />
+    <tenant-card-section-wrapper-block section-id=72996 date=date newsletter=newsletter title="Code Quiz of the Week" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72967 date=date newsletter=newsletter title="Basic Training" />
+    <tenant-card-section-wrapper-block section-id=72997 date=date newsletter=newsletter title="Eye On Safety" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72968 date=date newsletter=newsletter title="Lighting & Control" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72969 date=date newsletter=newsletter title="Mergers & Acquisitions" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72970 date=date newsletter=newsletter title="NEC" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72971 date=date newsletter=newsletter title="Case Study" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72972 date=date newsletter=newsletter title="In Case You Missed It" />
+    <tenant-card-section-wrapper-block section-id=72998 date=date newsletter=newsletter title="In Case You Missed It" />
 
     <tenant-section-spacer-block />
 

--- a/tenants/ecmweb/templates/neca-show-coverage.marko
+++ b/tenants/ecmweb/templates/neca-show-coverage.marko
@@ -1,0 +1,66 @@
+import emailX from "../config/email-x";
+
+$ const { newsletter, date } = data;
+$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <tenant-styles />
+  </@head>
+  <@body style="margin: 0px !important; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+    <tenant-header-block date=date newsletter=newsletter />
+
+    <!-- <tenant-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table> -->
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=73029 date=date newsletter=newsletter title="Show Highlights" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=72999 date=date newsletter=newsletter title="Editor's Choice" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=73000 date=date newsletter=newsletter title="Making Connections" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=73001 date=date newsletter=newsletter title="Top 50 Electrical Contractors" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=73002 date=date newsletter=newsletter title="Product Sourcing & Supply" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-card-section-wrapper-block section-id=73003 date=date newsletter=newsletter title="Trip Back in Time" />
+
+    <tenant-section-spacer-block />
+
+    <tenant-opt-out-block />
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/ecmweb/templates/safety-matters.marko
+++ b/tenants/ecmweb/templates/safety-matters.marko
@@ -36,55 +36,43 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72960 date=date newsletter=newsletter title="Special Report" />
+    <tenant-card-section-wrapper-block section-id=73006 date=date newsletter=newsletter title="Eye On Safety" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72961 date=date newsletter=newsletter title="Web Exclusive" />
+    <tenant-card-section-wrapper-block section-id=73007 date=date newsletter=newsletter title="Top Story" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72962 date=date newsletter=newsletter title="Top Story" />
+    <tenant-card-section-wrapper-block section-id=73008 date=date newsletter=newsletter title="Safety Sense" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72963 date=date newsletter=newsletter title="Around the Circuit" />
+    <tenant-card-section-wrapper-block section-id=73009 date=date newsletter=newsletter title="Forensic Friday" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72964 date=date newsletter=newsletter title="Code Quiz of the Week" />
+    <tenant-card-section-wrapper-block section-id=73010 date=date newsletter=newsletter title="Special Report" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72965 date=date newsletter=newsletter title="Safety Sense" />
+    <tenant-card-section-wrapper-block section-id=73011 date=date newsletter=newsletter title="Accidents & Investigations" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72966 date=date newsletter=newsletter title="Eye on Safety" />
+    <tenant-card-section-wrapper-block section-id=73012 date=date newsletter=newsletter title="Web Exclusive" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72967 date=date newsletter=newsletter title="Basic Training" />
+    <tenant-card-section-wrapper-block section-id=73013 date=date newsletter=newsletter title="Best Practices" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72968 date=date newsletter=newsletter title="Lighting & Control" />
+    <tenant-card-section-wrapper-block section-id=73014 date=date newsletter=newsletter title="Code Basics" />
 
     <tenant-section-spacer-block />
 
-    <tenant-card-section-wrapper-block section-id=72969 date=date newsletter=newsletter title="Mergers & Acquisitions" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72970 date=date newsletter=newsletter title="NEC" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72971 date=date newsletter=newsletter title="Case Study" />
-
-    <tenant-section-spacer-block />
-
-    <tenant-card-section-wrapper-block section-id=72972 date=date newsletter=newsletter title="In Case You Missed It" />
+    <tenant-card-section-wrapper-block section-id=73015 date=date newsletter=newsletter title="In Case You Missed It" />
 
     <tenant-section-spacer-block />
 


### PR DESCRIPTION
Added ability to override the button-style on a per-template basis, added additional 5 newsletters to EC&M.

![Screen Shot 2019-12-04 at 4 47 08 PM](https://user-images.githubusercontent.com/12496550/70188212-bb91af00-16b5-11ea-8b54-d898926c61f5.png)

![Screen Shot 2019-12-04 at 3 06 26 PM](https://user-images.githubusercontent.com/12496550/70188225-c1879000-16b5-11ea-83df-c340d485f896.png)


![Screen Shot 2019-12-04 at 2 42 20 PM](https://user-images.githubusercontent.com/12496550/70188231-c4828080-16b5-11ea-9a61-b29f6396f8e8.png)
