### PR TITLE
eTrain eNL (ECM) & header 'Description' added

### DIFF
--- a/tenants/asumag/components/blocks/header-blue.marko
+++ b/tenants/asumag/components/blocks/header-blue.marko
@@ -19,7 +19,7 @@ $ const {
       ${newsletter.name}
       </h1>
       <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
-      ${newsletter.description}
+      $!{newsletter.description}
       </p>
     </td>
     <td height="80" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">

--- a/tenants/asumag/components/blocks/header-red.marko
+++ b/tenants/asumag/components/blocks/header-red.marko
@@ -19,7 +19,7 @@ $ const {
       ${newsletter.name}
       </h1>
       <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
-      ${newsletter.description}
+      $!{newsletter.description}
       </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">

--- a/tenants/contractormag/components/blocks/header.marko
+++ b/tenants/contractormag/components/blocks/header.marko
@@ -18,6 +18,9 @@ $ const {
       <h1 style="color: #fff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
       ${newsletter.name}
       </h1>
+      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+        $!{newsletter.description}
+      </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">
       &nbsp;

--- a/tenants/ecmweb/components/blocks/header.marko
+++ b/tenants/ecmweb/components/blocks/header.marko
@@ -16,10 +16,10 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #052e4b; border-bottom: 2px solid #000000; background-color: #014750; margin-right: 10px;">
       <h1 style="color: #ffffff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
       <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
-      ${newsletter.description}
+        $!{newsletter.description}
       </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">

--- a/tenants/ecmweb/config/email-x.js
+++ b/tenants/ecmweb/config/email-x.js
@@ -73,6 +73,14 @@ config
       width: 670,
       height: 90,
     },
+  ])
+  .setAdUnits('etrain', [
+    {
+      name: 'leaderboardPrimary',
+      id: '5de9681776787a84a311bba4',
+      width: 670,
+      height: 90,
+    },
   ]);
 
 module.exports = config;

--- a/tenants/ecmweb/templates/etrain.marko
+++ b/tenants/ecmweb/templates/etrain.marko
@@ -1,0 +1,361 @@
+import emailX from "../config/email-x";
+
+$ const { newsletter, date } = data;
+$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
+$ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
+$ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
+$ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "font-weight": "bold",
+  "color": "#014750",
+  "font-size": "16px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+};
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #014750;";
+$ const buttonTextStyle = {
+  "color": "#ffffff",
+  "font-family": "Helvetica, Arial, sans-serif",
+  "font-size": "14px",
+  "font-weight": "bold",
+  "text-decoration": "none",
+  "text-transform": "uppercase"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-a-styles />
+  </@head>
+  <@body style="margin: 0px !important; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+    <tenant-header-block date=date newsletter=newsletter />
+
+    <!-- <common-style-a-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table> -->
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73049
+      title="Top Story"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73050
+      title="Special Report"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73061
+      title="Web Exclusive"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73049
+      title="Top Story"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73051
+      title="Basic Training"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73052
+      title="Eye On Safety"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73053
+      title="Safety Matters"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73054
+      title="Inspector Intel"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73055
+      title="Around The Circuit"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73056
+      title="Fleet Management"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73057
+      title="Training Dates"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73058
+      title="Maintenance Matters"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73059
+      title="Code Basics"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73060
+      title="Code Quiz of the Week"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73061
+      title="Web Exclusive"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73062
+      title="College Programs"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73063
+      title="Accidents & Investigations"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73064
+      title="Maintenance & Repairs"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73065
+      title="Market Study"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73066
+      title="In Case You Missed It"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-opt-out-block />
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/ewweb/components/blocks/header.marko
+++ b/tenants/ewweb/components/blocks/header.marko
@@ -16,8 +16,11 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #052e4b; border-bottom: 2px solid #000000; background-color: #00464f; margin-right: 10px;">
       <h1 style="color: #fff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
+      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+        $!{newsletter.description}
+      </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">
       &nbsp;

--- a/tenants/hpac/components/blocks/header.marko
+++ b/tenants/hpac/components/blocks/header.marko
@@ -16,9 +16,11 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #052e4b; border-bottom: 2px solid #000000; background-color: #0081a1; margin-right: 10px;">
       <h1 style="color: #fff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
-      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">${newsletter.teaser}</p>
+      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+        $!{newsletter.description}
+      </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">
       &nbsp;

--- a/tenants/rermag/components/blocks/header-blue.marko
+++ b/tenants/rermag/components/blocks/header-blue.marko
@@ -16,10 +16,10 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #000000; border-bottom: 2px solid #000000; background-color: #005aa2; margin-right: 10px;">
       <h1 style="color: #ffffff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
       <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
-      ${newsletter.description}
+        $!{newsletter.description}
       </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">

--- a/tenants/rermag/components/blocks/header-red.marko
+++ b/tenants/rermag/components/blocks/header-red.marko
@@ -16,10 +16,10 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #052e4b; border-bottom: 2px solid #000000; background-color: #87002f; margin-right: 10px;">
       <h1 style="color: #ffffff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
       <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
-      ${newsletter.description}
+        $!{newsletter.description}
       </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">

--- a/tenants/tdworld/components/blocks/header.marko
+++ b/tenants/tdworld/components/blocks/header.marko
@@ -16,8 +16,11 @@ $ const {
     </td>
     <td height="75" valign="center" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #052e4b; border-bottom: 2px solid #000000; background-color: #ffffff; margin-right: 10px;">
       <h1 style="color: #00af97; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
-      ${newsletter.name}
+        ${newsletter.name}
       </h1>
+      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+        $!{newsletter.description}
+      </p>
     </td>
     <td height="75" valign="top" style="font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-collapse: separate; width: 5px;">
       &nbsp;


### PR DESCRIPTION
new eTrain eNL:
![Screen Shot 2019-12-05 at 2 51 30 PM](https://user-images.githubusercontent.com/12496550/70273103-0fac9a00-176f-11ea-850d-79b5dd8d244e.png)

Also added description to all remaining newsletters (only on a handful of them at the moments)
![Screen Shot 2019-12-05 at 2 51 38 PM](https://user-images.githubusercontent.com/12496550/70273145-2226d380-176f-11ea-8eb2-a8d31c8c449f.png)
