### PR TITLE
Tdworld cleanup

### DIFF
--- a/tenants/tdworld/components/blocks/header.marko
+++ b/tenants/tdworld/components/blocks/header.marko
@@ -18,7 +18,7 @@ $ const {
       <h1 style="color: #00af97; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
         ${newsletter.name}
       </h1>
-      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+      <p style="color: #8c9190; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -5px 0 0 15px; font-weight: bold;">
         $!{newsletter.description}
       </p>
     </td>
@@ -29,8 +29,8 @@ $ const {
       <marko-newsletter-imgix
           src="/files/base/ebm/tdworld/image/static/newsletter/header_logo.jpg"
           alt=newsletter.name
-          options={ w: 120 }
-          attrs={ border: 0, width: 120 }
+          options={ w: 140 }
+          attrs={ border: 0, width: 140 }
         >
         </marko-newsletter-imgix>
     </td>

--- a/tenants/tdworld/config/email-x.js
+++ b/tenants/tdworld/config/email-x.js
@@ -12,16 +12,10 @@ config
   ])
   .setAdUnits('europe-insights', [
     {
-      name: 'mrPrimary',
+      name: 'leaderboardPrimary',
       id: '5de58977d300776ad4f1e8ce',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'mrSecondary',
-      id: '5de589a876787a01ce1153a1',
-      width: 300,
-      height: 250,
+      width: 670,
+      height: 90,
     },
   ])
   .setAdUnits('grid-innovations', [
@@ -34,24 +28,18 @@ config
   ])
   .setAdUnits('lineman-life', [
     {
-      name: 'mrPrimary',
+      name: 'leaderboardPrimary',
       id: '5de58be6d3007766def1e921',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'mrSecondary',
-      id: '5de58bf876787a36371153f3',
-      width: 300,
-      height: 250,
+      width: 670,
+      height: 90,
     },
   ])
   .setAdUnits('international-linemans-rodeo', [
     {
-      name: 'mrPrimary',
+      name: 'leaderboardPrimary',
       id: '5de58cca76787a0248115422',
-      width: 300,
-      height: 250,
+      width: 670,
+      height: 90,
     },
   ])
   .setAdUnits('projects-in-progress', [
@@ -91,18 +79,6 @@ config
       width: 670,
       height: 90,
     },
-    {
-      name: 'mrPrimary',
-      id: '5de564ffd30077f59ef1e7e5',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'mrSecondary',
-      id: '5de5654ad30077c545f1e825',
-      width: 300,
-      height: 250,
-    },
   ])
   .setAdUnits('ieee-pes-show-update', [
     {
@@ -111,17 +87,13 @@ config
       width: 670,
       height: 90,
     },
+  ])
+  .setAdUnits('careers', [
     {
-      name: 'mrPrimary',
-      id: '5de5902676787a107811562f',
-      width: 300,
-      height: 250,
-    },
-    {
-      name: 'mrSecondary',
-      id: '5de59036d300774a5bf1eb1c',
-      width: 300,
-      height: 250,
+      name: 'leaderboardPrimary',
+      id: '5dea688bd30077bff8f24700',
+      width: 670,
+      height: 90,
     },
   ]);
 module.exports = config;

--- a/tenants/tdworld/templates/careers.marko
+++ b/tenants/tdworld/templates/careers.marko
@@ -1,0 +1,122 @@
+import emailX from "../config/email-x";
+
+$ const { newsletter, date } = data;
+$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
+$ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;";
+$ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
+$ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "font-weight": "bold",
+  "color": "#00b398",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+};
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #00b398;";
+$ const buttonTextStyle = {
+  "color": "#ffffff",
+  "font-family": "Helvetica, Arial, sans-serif",
+  "font-size": "14px",
+  "font-weight": "bold",
+  "text-decoration": "none",
+  "text-transform": "uppercase"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-a-styles />
+  </@head>
+  <@body style="margin: 0px !important; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+   <tenant-header-block date=date newsletter=newsletter />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-section-wrapper-block
+      section-id=73072
+      title="Top Story"
+      limit=1
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <!-- <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table>
+
+    <common-style-a-section-spacer-block /> -->
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73073
+      title="News and Highlights"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73074
+      title="Training & Technology"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=73075
+      title="Career Fairs"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-opt-out-block />
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
Uploaded new logo and increased the width to 140, so now it’s centered.  Also tweaked the newsletter description a bit to more closely match what they have on their legacy newsletters.

![Screen Shot 2019-12-06 at 8 37 46 AM](https://user-images.githubusercontent.com/12496550/70332002-41247480-1806-11ea-9366-c89baa1c6984.png)


Standardized email-x: What I originally thought were 300x250s will actually be text-ads.  They may still use leaderboards (and do in some) so I removed all 300x250s and replace them with a single leaderboard. These changes are reflected in emailx as well.

Lastly, I added a new "Careers" eNL that was missed
![Screen Shot 2019-12-06 at 9 06 07 AM](https://user-images.githubusercontent.com/12496550/70332686-be9cb480-1807-11ea-8f50-2277f28f774d.png)
