### PR TITLE
To camel or not to camel

### DIFF
--- a/packages/common/components/style-a/blocks/opt-out.marko
+++ b/packages/common/components/style-a/blocks/opt-out.marko
@@ -41,7 +41,7 @@ $ const socialMediaProviders = config.getAsArray('socialMediaLinks');
       </p>
 
       <p style="margin:0px;margin-bottom:1em;">
-        If this email was forwarded to you and you are interested in subscribing, please <a style="text-decoration: underline !important;" href=`${config.get("optOut.signup")}`>click here</a> to sign-up.
+        If this email was forwarded to you and you are interested in subscribing, please <a style="text-decoration: underline !important;" href=`${config.get("optOut.signUp")}`>click here</a> to sign-up.
       </p>
 
       <p style="margin:0px;margin-bottom:1em;">


### PR DESCRIPTION
set as “signUp” everywhere else (isntead of “signup”)