### PR TITLE
nbsp; fix in newsletters

### DIFF
--- a/packages/common/components/style-a/blocks/promotion-full.marko
+++ b/packages/common/components/style-a/blocks/promotion-full.marko
@@ -57,11 +57,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
     <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
       <common-table width=innerTableWidth style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
         <tr>
-          <td>
-            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              &nbsp;
-            </div>
-          </td>
+          <td>&nbsp;</td>
         </tr>
         <tr>
           <td>

--- a/packages/common/components/style-a/blocks/simple-card-full.marko
+++ b/packages/common/components/style-a/blocks/simple-card-full.marko
@@ -89,7 +89,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
             <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
             </marko-core-obj-text>
-            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+            <div height="10">&nbsp;</div>
             <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
           </td>
         </tr>

--- a/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
+++ b/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
@@ -75,7 +75,7 @@ $ const innerPadding = 20;
               <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+              <div height="10">&nbsp;</div>
               <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </td>
           </tr>

--- a/packages/common/components/style-a/blocks/simple-card.marko
+++ b/packages/common/components/style-a/blocks/simple-card.marko
@@ -69,7 +69,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
             <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
             </marko-core-obj-text>
-            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+            <div height="10">&nbsp;</div>
             <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             <common-table align="center" padding=0 spacing=0>
               <tr>


### PR DESCRIPTION
Tweaked the `&nbsp;` a bit so gmail is no longer grumpy.

