### PR TITLE
New Title+Teaser Block

### DIFF
--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -162,6 +162,35 @@
     "@main-table-style": "string",
     "@content-link-style": "object"
   },
+  "<common-style-a-title-teaser-block>": {
+    "template": "./title-teaser.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@title": "string",
+    "@title-table-style": "string",
+    "@teaser-style": "object",
+    "@title-style": "string",
+    "@main-table-style": "string",
+    "@content-link-style": "object"
+  },
   "<common-style-a-simple-card-block>": {
     "template": "./simple-card.marko",
     "@node": "object",

--- a/packages/common/components/style-a/blocks/title-teaser.marko
+++ b/packages/common/components/style-a/blocks/title-teaser.marko
@@ -10,8 +10,16 @@ $ const {
   sectionId,
   title,
   limit,
-  skip
+  skip,
 } = input;
+$ const teaserStyle = defaultValue(input.teaserStyle, {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+});
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
@@ -54,6 +62,8 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                 <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "20px", "text-align": "left" } } >
                   <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                 </marko-core-obj-text>
+
+                <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
               </for>
             </td>
           </tr>

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -130,7 +130,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-section-wrapper-block
+    <common-style-a-title-teaser-block
       section-id=71096
       title="Job Opportunities"
       date=date


### PR DESCRIPTION
Very simple; just pulls title and teaser.  No queries for content type, button styles, etc.  All content looks the same: title + teaser.

Also fixed the spacing on the list block, the block had a huge space at the top then almost no space in-between titles so they looked it they were all one giant paragraph.

![Screen Shot 2019-12-16 at 9 04 36 AM](https://user-images.githubusercontent.com/12496550/70917559-29f23d80-1fe3-11ea-82f8-e95e4cc3e125.png)
