### PR TITLE
Promotion style added to “full-third-two-thirds-section-wrapper”

### DIFF
--- a/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
@@ -51,13 +51,13 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>
-                  <common-style-a-simple-card-third-two-thirds-block
-                    node=node
-                    content-link-style=contentLinkStyle
-                    button-style=buttonStyle
-                    button-text-style=buttonTextStyle
-                    teaser-style=teaserStyle
-                  />
+                <common-style-a-simple-card-third-two-thirds-block
+                  node=node
+                  content-link-style=contentLinkStyle
+                  button-style=buttonStyle
+                  button-text-style=buttonTextStyle
+                  teaser-style=teaserStyle
+                />
                 <if(!isLast(nodes, index))>
                   <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
                     <tr>

--- a/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
@@ -51,13 +51,25 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>
-                <common-style-a-simple-card-third-two-thirds-block
-                  node=node
-                  content-link-style=contentLinkStyle
-                  button-style=buttonStyle
-                  button-text-style=buttonTextStyle
-                  teaser-style=teaserStyle
-                />
+                <if(node.type === "promotion")>
+                  <common-style-a-promotion-block
+                    node=node
+                    alignment="left"
+                    img-width=660
+                    table-width=700
+                    content-link-style=contentLinkStyle
+                    teaser-style=teaserStyle
+                  />
+                </if>
+                <else>
+                  <common-style-a-simple-card-third-two-thirds-block
+                    node=node
+                    content-link-style=contentLinkStyle
+                    button-style=buttonStyle
+                    button-text-style=buttonTextStyle
+                    teaser-style=teaserStyle
+                  />                </else>
+
                 <if(!isLast(nodes, index))>
                   <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
                     <tr>

--- a/tenants/trailerbodybuilders/components/blocks/full-third-two-thirds-section-wrapper.marko
+++ b/tenants/trailerbodybuilders/components/blocks/full-third-two-thirds-section-wrapper.marko
@@ -51,13 +51,25 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>
+                <if(node.type === "promotion")>
+                  <common-style-a-promotion-block
+                    node=node
+                    alignment="left"
+                    img-width=660
+                    table-width=700
+                    content-link-style=contentLinkStyle
+                    teaser-style=teaserStyle
+                  />
+                </if>
+                <else>
                   <common-style-a-simple-card-third-two-thirds-block
                     node=node
                     content-link-style=contentLinkStyle
                     button-style=buttonStyle
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
-                  />
+                  />                </else>
+
                 <if(!isLast(nodes, index))>
                   <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
                     <tr>

--- a/tenants/trailerbodybuilders/components/blocks/marko.json
+++ b/tenants/trailerbodybuilders/components/blocks/marko.json
@@ -20,5 +20,36 @@
       "type": "object",
       "required": true
     }
+  },
+  "<tenant-full-third-two-thirds-section-wrapper>": {
+    "template": "./full-third-two-thirds-section-wrapper.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@title": "string",
+    "@title-table-style": "string",
+    "@title-style": "string",
+    "@teaser-style": "object",
+    "@button-style": "string",
+    "@button-text-style": "object",
+    "@main-table-style": "string",
+    "@content-link-style": "object"
   }
 }

--- a/tenants/trailerbodybuilders/templates/market-watch.marko
+++ b/tenants/trailerbodybuilders/templates/market-watch.marko
@@ -70,7 +70,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
+    <tenant-full-third-two-thirds-section-wrapper
       section-id=74407
       title="From The Editor"
       date=date
@@ -85,7 +85,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
+    <tenant-full-third-two-thirds-section-wrapper
       section-id=74408
       title="Industry Update"
       date=date
@@ -100,7 +100,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
+    <tenant-full-third-two-thirds-section-wrapper
       section-id=74409
       title="New to the Market"
       date=date


### PR DESCRIPTION
Per Richele, adding a custom style for promotions in this template layout.

![image](https://user-images.githubusercontent.com/12496550/70921977-e996bd80-1fea-11ea-8c20-d9565e72e813.png)
