### PR TITLE
QMN Outlook Fix

### DIFF
--- a/tenants/industryweek/templates/quick-manufacturing-news.marko
+++ b/tenants/industryweek/templates/quick-manufacturing-news.marko
@@ -119,7 +119,7 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
@@ -246,7 +246,7 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
@@ -382,7 +382,7 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
@@ -518,7 +518,7 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >


### PR DESCRIPTION
Reduced table width by 20px because Outlook gets crabby and likes to add extra spacing on it’s own.

![image](https://user-images.githubusercontent.com/12496550/70938558-08597c00-200c-11ea-90a0-84836eeff4b5.png)


How it looks currently:
![image](https://user-images.githubusercontent.com/12496550/70938601-1d360f80-200c-11ea-8454-c00b7db7e146.png)
