### PR TITLE
Update electronicDesign layouts & blocks

### DIFF
--- a/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
+++ b/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
@@ -55,38 +55,33 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
           <tr>
             <td valign="top" align="center">
               <for|node, index| of=nodes>
-                <common-table width="595" style="border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="center" class="center" padding=0 spacing=0>
+                $ const fallbackText = node.type === 'promotion' ? 'Advertisement' : '&nbsp;';
+                <common-table width="595" style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="center" class="main center" padding=0 spacing=0>
                   <tr>
                     <td>
-                      <common-table width="595" style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="center" class="center" padding=0 spacing=0>
-                        <tr>
-                          <td>
-                            <div style=`${labelStyle}`>
-                              $!{getSponsoredByText(node, '&nbsp;')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td>
-                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                              <marko-newsletter-imgix
-                                src=image.src
-                                alt=image.alt
-                                options={ w: 595 }
-                                class="main"
-                                attrs={ border: 0, width: 595 }
-                              >
-                                <@link href=node.siteContext.url target="_blank" />
-                              </marko-newsletter-imgix>
-                            </marko-core-obj-value>
-                            <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
-                          </td>
-                        </tr>
-                        <tr>
-                          <td>&nbsp;</td>
-                        </tr>
-                      </common-table>
+                      <div style=`${labelStyle}`>
+                        $!{getSponsoredByText(node, fallbackText)}
+                      </div>
                     </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                        <marko-newsletter-imgix
+                          src=image.src
+                          alt=image.alt
+                          options={ w: 595 }
+                          class="main"
+                          attrs={ border: 0, width: 595 }
+                        >
+                          <@link href=node.siteContext.url target="_blank" />
+                        </marko-newsletter-imgix>
+                      </marko-core-obj-value>
+                      <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>&nbsp;</td>
                   </tr>
                 </common-table>
                 <if(!isLast(nodes, index))>

--- a/packages/common/components/style-a/default-style.marko
+++ b/packages/common/components/style-a/default-style.marko
@@ -62,6 +62,9 @@
     .right img {
       max-width: 315px;
     }
+    .main.header img {
+      max-width: 345px;
+    }
     .right .advertisement {
       margin-right: 15px;
       margin-top: 12px;

--- a/tenants/electronicdesign/components/blocks/header.marko
+++ b/tenants/electronicdesign/components/blocks/header.marko
@@ -4,7 +4,7 @@ $ const {
   imagePath
 } = input;
 
-<common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+<common-table width="700" style="border-collapse:collapse;" align="center" class="main header" padding=0 spacing=0>
   <tr>
     <td>
       <span>

--- a/tenants/electronicdesign/templates/analog-power-source.marko
+++ b/tenants/electronicdesign/templates/analog-power-source.marko
@@ -66,17 +66,17 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73112
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -92,6 +92,21 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74490
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=featuredContentLinkStyle
+      teaser-style=featuredTeaserStyle
+      label-style=featuredLabelStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/automotive-electronics.marko
+++ b/tenants/electronicdesign/templates/automotive-electronics.marko
@@ -66,17 +66,17 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73122
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -92,6 +92,21 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74491
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=featuredContentLinkStyle
+      teaser-style=featuredTeaserStyle
+      label-style=featuredLabelStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/electronic-design-today.marko
+++ b/tenants/electronicdesign/templates/electronic-design-today.marko
@@ -66,17 +66,17 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73111
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -92,6 +92,21 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74492
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=featuredContentLinkStyle
+      teaser-style=featuredTeaserStyle
+      label-style=featuredLabelStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/iot-for-engineers.marko
+++ b/tenants/electronicdesign/templates/iot-for-engineers.marko
@@ -66,17 +66,17 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=74447
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -92,6 +92,21 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74493
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=featuredContentLinkStyle
+      teaser-style=featuredTeaserStyle
+      label-style=featuredLabelStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />


### PR DESCRIPTION
They all now pull latest with one featured at the top and then a sponsored ad section at the bottom.

![designToday](https://user-images.githubusercontent.com/3845869/70938789-83229700-200c-11ea-9ef6-0346dcd322ed.jpg)
