### PR TITLE
Update feature ad list sponsor layouts with new Feature || 180 || featuredAd layout

### DIFF
--- a/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/full-third-two-thirds-section-wrapper.marko
@@ -37,17 +37,19 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
         queryFragment: contentList,
       }>
         <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-          <tr>
-            <td>
-              <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
-                <tr>
-                  <td>
-                    <h3 style=`${titleStyle}`>${title}</h3>
-                  </td>
-                </tr>
-              </common-table>
-            </td>
-          </tr>
+          <if(title)>
+            <tr>
+              <td>
+                <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>
+                      <h3 style=`${titleStyle}`>${title}</h3>
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+          </if>
           <tr>
             <td valign="top">
               <for|node, index| of=nodes>

--- a/tenants/electronicdesign/templates/analog-power-source.marko
+++ b/tenants/electronicdesign/templates/analog-power-source.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -81,7 +65,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73112
       date=date
       skip=1

--- a/tenants/electronicdesign/templates/analog-power-source.marko
+++ b/tenants/electronicdesign/templates/analog-power-source.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/automotive-electronics.marko
+++ b/tenants/electronicdesign/templates/automotive-electronics.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -81,7 +65,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73122
       date=date
       skip=1

--- a/tenants/electronicdesign/templates/automotive-electronics.marko
+++ b/tenants/electronicdesign/templates/automotive-electronics.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/electronic-design-today.marko
+++ b/tenants/electronicdesign/templates/electronic-design-today.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -87,8 +78,8 @@ $ const buttonTextStyle = {
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
       content-link-style=contentLinkStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/electronicdesign/templates/electronic-design-today.marko
+++ b/tenants/electronicdesign/templates/electronic-design-today.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -81,7 +65,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73111
       date=date
       skip=1
@@ -102,9 +86,7 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
+      content-link-style=contentLinkStyle
       button-style=featuredButtonStyle
       button-text-style=featuredButtonTextStyle
     />

--- a/tenants/electronicdesign/templates/iot-for-engineers.marko
+++ b/tenants/electronicdesign/templates/iot-for-engineers.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -81,7 +65,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=74447
       date=date
       skip=1

--- a/tenants/electronicdesign/templates/iot-for-engineers.marko
+++ b/tenants/electronicdesign/templates/iot-for-engineers.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/fleetowner/templates/commercial-work-truck.marko
+++ b/tenants/fleetowner/templates/commercial-work-truck.marko
@@ -3,31 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -71,10 +47,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -87,6 +62,19 @@ $ const buttonTextStyle = {
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74498
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle

--- a/tenants/fleetowner/templates/equipment-weekly.marko
+++ b/tenants/fleetowner/templates/equipment-weekly.marko
@@ -3,31 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -71,10 +47,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -87,6 +62,19 @@ $ const buttonTextStyle = {
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74499
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle

--- a/tenants/hydraulicspneumatics/templates/fluid-power.marko
+++ b/tenants/hydraulicspneumatics/templates/fluid-power.marko
@@ -3,10 +3,10 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #034b8d; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredContentLinkStyle = {
   "font-weight": "bold",
-  "color": "#fff",
+  "color": "#000",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
@@ -16,10 +16,9 @@ $ const featuredTeaserStyle = {
   "line-height": "146%",
   "margin": "0",
   "padding": "0",
-  "color": "#fff",
+  "color": "#000",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -66,22 +65,22 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73114
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73114
       date=date
       skip=1
@@ -92,6 +91,20 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74494
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=featuredContentLinkStyle
+      teaser-style=featuredTeaserStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/machinedesign/templates/3d-printing-cad.marko
+++ b/tenants/machinedesign/templates/3d-printing-cad.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -79,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73124
       date=date
       skip=1

--- a/tenants/machinedesign/templates/3d-printing-cad.marko
+++ b/tenants/machinedesign/templates/3d-printing-cad.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -85,10 +76,9 @@ $ const buttonTextStyle = {
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
       content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/machinedesign/templates/daily.marko
+++ b/tenants/machinedesign/templates/daily.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -79,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=74486
       date=date
       skip=1

--- a/tenants/machinedesign/templates/daily.marko
+++ b/tenants/machinedesign/templates/daily.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -84,11 +75,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/machinedesign/templates/medical-design.marko
+++ b/tenants/machinedesign/templates/medical-design.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -63,7 +54,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-product-spotlight-180-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73125
       date=date
       skip=1
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-opt-out-block />

--- a/tenants/machinedesign/templates/medical-design.marko
+++ b/tenants/machinedesign/templates/medical-design.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -79,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-product-spotlight-180-section-wrapper-block
       section-id=73125
       date=date
       skip=1

--- a/tenants/machinedesign/templates/motion.marko
+++ b/tenants/machinedesign/templates/motion.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-opt-out-block />

--- a/tenants/machinedesign/templates/motion.marko
+++ b/tenants/machinedesign/templates/motion.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -79,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=74469
       date=date
       skip=1

--- a/tenants/machinedesign/templates/product-spotlight.marko
+++ b/tenants/machinedesign/templates/product-spotlight.marko
@@ -4,31 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -71,10 +46,9 @@ $ const buttonTextStyle = {
       date=date
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/machinedesign/templates/robotics-automation.marko
+++ b/tenants/machinedesign/templates/robotics-automation.marko
@@ -4,15 +4,6 @@ $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +77,9 @@ $ const buttonTextStyle = {
       limit=1
       newsletter=newsletter
       main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-opt-out-block />

--- a/tenants/machinedesign/templates/robotics-automation.marko
+++ b/tenants/machinedesign/templates/robotics-automation.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -79,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73126
       date=date
       skip=1

--- a/tenants/mwrf/templates/defense-electronics.marko
+++ b/tenants/mwrf/templates/defense-electronics.marko
@@ -2,33 +2,7 @@ import emailX from "../config/email-x";
 
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
-$ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -66,22 +40,22 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73115
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73115
       date=date
       skip=1
@@ -89,6 +63,21 @@ $ const buttonTextStyle = {
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74495
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle

--- a/tenants/sourcetoday/templates/source-today.marko
+++ b/tenants/sourcetoday/templates/source-today.marko
@@ -3,23 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredLabelStyle =  "font-size: 12px; line-height: 146%; margin: 0; padding: 0; color: #fff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
@@ -29,6 +13,7 @@ $ const featuredButtonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const adMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -66,22 +51,22 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
+    <common-style-a-featured-section-wrapper-block
       section-id=73121
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      label-style=featuredLabelStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73121
       date=date
       skip=1
@@ -92,6 +77,19 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74496
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=featuredButtonStyle
+      button-text-style=featuredButtonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -3,31 +3,7 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -86,11 +62,12 @@ $ const buttonTextStyle = {
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -103,6 +80,19 @@ $ const buttonTextStyle = {
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-featured-ad-wrapper-block
+      section-id=74497
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle


### PR DESCRIPTION
The new version starts with the Featured Section Layout with the large full width image, title teaser layout.  Then the next section is the 180 image spot light layout that supports additional promotions being scheduled to it and the last item is the featured ad table.  It will display the Advertise Sponso logic then 595px image, and then body copy.

![fluidPower](https://user-images.githubusercontent.com/3845869/70958028-939f3580-203d-11ea-865b-be5eb32b15d0.jpg)
