### PR TITLE
Cleanup/Bug fixes

### DIFF
--- a/packages/common/components/style-a/blocks/promotion-full.marko
+++ b/packages/common/components/style-a/blocks/promotion-full.marko
@@ -25,7 +25,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, 'Advertisment')}
+              $!{getSponsoredByText(node, 'Advertisement')}
             </div>
           </td>
         </tr>

--- a/packages/common/components/style-a/blocks/promotion.marko
+++ b/packages/common/components/style-a/blocks/promotion.marko
@@ -25,7 +25,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, 'Advertisment')}
+              $!{getSponsoredByText(node, 'Advertisement')}
             </div>
           </td>
         </tr>

--- a/tenants/fleetowner/config/email-x.js
+++ b/tenants/fleetowner/config/email-x.js
@@ -6,8 +6,8 @@ config
     {
       name: 'leaderboardPrimary',
       id: '5df1578dd30077fa36f2ae8d',
-      width: 670,
-      height: 90,
+      width: 580,
+      height: 80,
     },
   ])
   .setAdUnits('fleet-owner-newsline', [
@@ -30,20 +30,20 @@ config
       height: 80,
     },
   ])
-  .setAdUnits('commercial-work-truck', [
+  .setAdUnits('heavy-duty-pickup-van', [
     {
       name: 'leaderboardPrimary',
       id: '5df24f36d30077482ef2b38a',
-      width: 670,
-      height: 90,
+      width: 580,
+      height: 80,
     },
   ])
   .setAdUnits('info-tech', [
     {
       name: 'leaderboardPrimary',
       id: '5df7d0e076787a5327126a80',
-      width: 670,
-      height: 90,
+      width: 580,
+      height: 80,
     },
   ]);
 module.exports = config;

--- a/tenants/fleetowner/templates/equipment-weekly.marko
+++ b/tenants/fleetowner/templates/equipment-weekly.marko
@@ -42,34 +42,6 @@ $ const buttonTextStyle = {
     <common-style-a-section-spacer-block />
 
     <common-style-a-featured-section-wrapper-block
-      section-id=74448
-      date=date
-      limit=1
-      newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74448
-      date=date
-      skip=1
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-featured-ad-wrapper-block
       section-id=74499
       date=date
       limit=1
@@ -81,6 +53,49 @@ $ const buttonTextStyle = {
     />
 
     <common-style-a-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table>
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-product-spotlight-180-section-wrapper-block
+      section-id=74448
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <!-- <common-style-a-featured-ad-wrapper-block
+      section-id=74499 #Previously Sponsored
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block /> -->
 
     <common-style-a-opt-out-block />
 

--- a/tenants/fleetowner/templates/fleet-owner-newsline.marko
+++ b/tenants/fleetowner/templates/fleet-owner-newsline.marko
@@ -8,7 +8,7 @@ $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sa
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredContentLinkStyle = {
   "font-weight": "bold",
-  "color": "#fff",
+  "color": "#ffffff",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
@@ -18,10 +18,10 @@ $ const featuredTeaserStyle = {
   "line-height": "146%",
   "margin": "0",
   "padding": "0",
-  "color": "#fff",
+  "color": "#ffffff",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
+$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #ffffff;";
 $ const featuredButtonTextStyle = {
   "color": "#333333",
   "font-family": "Helvetica, Arial, sans-serif",
@@ -67,24 +67,9 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
-          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
-            Advertisement
-          </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
-            <@ad-unit ...leaderboardPrimary />
-            <@params date=date email="@{email name}@"/>
-          </marko-newsletters-email-x-display>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
 
     <common-style-a-featured-section-wrapper-block
-      section-id=73113
+      section-id=74513
       date=date
       limit=1
       newsletter=newsletter
@@ -97,10 +82,41 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+    <common-style-a-product-spotlight-180-section-wrapper-block
+      section-id=73113
+      date=date
+      limit=2
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
       <tr>
         <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
-          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table>
+
+    <common-style-a-section-spacer-block />
+
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999999;text-align:left;">
             Advertisement
           </h3>
           <marko-newsletters-email-x-display decoded-params=["email"]>
@@ -116,8 +132,7 @@ $ const buttonTextStyle = {
     <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73113
       date=date
-      skip=1
-      limit=3
+      skip=2
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
@@ -129,10 +144,10 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-     <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffffff;" align="center" class="main" padding=0 spacing=0>
       <tr>
         <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
-          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999999;text-align:left;">
             Advertisement
           </h3>
           <marko-newsletters-email-x-display decoded-params=["email"]>
@@ -142,21 +157,6 @@ $ const buttonTextStyle = {
         </td>
       </tr>
     </common-table>
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=73113
-      date=date
-      skip=4
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
+++ b/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
@@ -2,45 +2,19 @@ import emailX from "../config/email-x";
 
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
-$ const leaderboardSecondary = emailX.getAdUnit({ name: "leaderboardSecondary", alias: newsletter.alias });
-$ const leaderboardTertiary = emailX.getAdUnit({ name: "leaderboardTertiary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
-$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
-$ const featuredContentLinkStyle = {
-  "font-weight": "bold",
-  "color": "#fff",
-  "font-size": "19.5px",
-  "line-height": "20px",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
-};
-$ const featuredTeaserStyle = {
-  "font-size": "12px",
-  "line-height": "146%",
-  "margin": "0",
-  "padding": "0",
-  "color": "#fff",
-  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
-};
-$ const featuredButtonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #fff;";
-$ const featuredButtonTextStyle = {
-  "color": "#333333",
-  "font-family": "Helvetica, Arial, sans-serif",
-  "font-size": "14px",
-  "font-weight": "bold",
-  "text-decoration": "none",
-  "text-transform": "uppercase"
-};
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const contentLinkStyle = {
   "font-weight": "bold",
-  "color": "#0190ba",
+  "color": "#0a2536",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 };
-$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0190ba;";
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0a2536;";
 $ const buttonTextStyle = {
   "color": "#ffffff",
   "font-family": "Helvetica, Arial, sans-serif",
@@ -63,20 +37,21 @@ $ const buttonTextStyle = {
       name=newsletter.name
       date=date
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/info_tech_header.jpg" date=date newsletter=newsletter />
+    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/commercial_work_trucks_header.jpg" date=date newsletter=newsletter />
 
     <common-style-a-section-spacer-block />
 
     <common-style-a-featured-section-wrapper-block
-      section-id=74489
+      section-id=74498
       date=date
       limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />
@@ -98,9 +73,11 @@ $ const buttonTextStyle = {
     <common-style-a-section-spacer-block />
 
     <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74488
+      section-id=74454
       date=date
       newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
@@ -108,6 +85,19 @@ $ const buttonTextStyle = {
     />
 
     <common-style-a-section-spacer-block />
+
+    <!-- <common-style-a-featured-ad-wrapper-block
+      section-id=74498 #Previously Sponsored
+      date=date
+      limit=1
+      newsletter=newsletter
+      main-table-style=featuredMainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block /> -->
 
     <common-style-a-opt-out-block />
 

--- a/tenants/fleetowner/templates/top-5.marko
+++ b/tenants/fleetowner/templates/top-5.marko
@@ -9,12 +9,12 @@ $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const contentLinkStyle = {
   "font-weight": "bold",
-  "color": "#0a2536",
+  "color": "#d00a2d",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 };
-$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0a2536;";
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #d00a2d;";
 $ const buttonTextStyle = {
   "color": "#ffffff",
   "font-family": "Helvetica, Arial, sans-serif",
@@ -37,12 +37,12 @@ $ const buttonTextStyle = {
       name=newsletter.name
       date=date
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/commercial_work_trucks_header.jpg" date=date newsletter=newsletter />
+    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/top-5.jpg" date=date newsletter=newsletter />
 
     <common-style-a-section-spacer-block />
 
     <common-style-a-featured-section-wrapper-block
-      section-id=74454
+      section-id=74530
       date=date
       limit=1
       newsletter=newsletter
@@ -54,27 +54,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74454
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+            Advertisement
+          </h3>
+          <marko-newsletters-email-x-display decoded-params=["email"]>
+            <@ad-unit ...leaderboardPrimary />
+            <@params date=date email="@{email name}@"/>
+          </marko-newsletters-email-x-display>
+        </td>
+      </tr>
+    </common-table>
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-product-spotlight-180-section-wrapper-block
+      section-id=74531
       date=date
-      skip=1
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-featured-ad-wrapper-block
-      section-id=74498
-      date=date
-      limit=1
-      newsletter=newsletter
-      main-table-style=featuredMainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle

--- a/tenants/industryweek/templates/supply-chain-insights.marko
+++ b/tenants/industryweek/templates/supply-chain-insights.marko
@@ -95,7 +95,7 @@ $ const teaserStyle = {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=410 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >

--- a/tenants/trucker/config/core.js
+++ b/tenants/trucker/config/core.js
@@ -4,8 +4,8 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://www.trucker.com/subscribe',
-    signUp: 'https://www.trucker.com/subscribe',
+    manageSubscriptions: 'https://endeavor.dragonforms.com/AMTKPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
+    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=AMTKPrefPage',
   },
   socialMediaLinks: [
     {

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -96,8 +96,8 @@ $ const buttonTextStyle = {
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     /> -->
-
-    <common-style-a-section-spacer-block />
+<!--
+    <common-style-a-section-spacer-block /> -->
 
     <common-style-a-opt-out-block />
 

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -41,7 +41,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+    <common-table width="700" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
       <tr>
         <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
     <common-style-a-section-spacer-block />
 
     <common-style-a-featured-section-wrapper-block
-      section-id=73110
+      section-id=74525
       date=date
       limit=1
       newsletter=newsletter
@@ -75,7 +75,6 @@ $ const buttonTextStyle = {
     <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73110
       date=date
-      skip=1
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
@@ -87,8 +86,8 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-ad-wrapper-block
-      section-id=74497
+    <!-- <common-style-a-featured-ad-wrapper-block
+      section-id=74497 #section does not exsit
       date=date
       limit=1
       newsletter=newsletter
@@ -96,7 +95,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
-    />
+    /> -->
 
     <common-style-a-section-spacer-block />
 


### PR DESCRIPTION
- ‘Advertisement’ Spelling Fix

- American Trucker Daily "Featured" block added
- Outlook Bug fix 

- Restructure of FO Newsline:
Leaderboard ads re-positioned (per Richele), added a “Featured” section to display at the top to prevent ads from displaying in that format.  This way they can just ensure that articles/content get that big featured wrapper style.
Also modified the color hex to be 6 digits instead of 3.  Better practice for older newsletter clients.

![image](https://user-images.githubusercontent.com/12496550/71005336-1d381d00-20a9-11ea-976e-8dfae31c3d13.png)
