### PR TITLE
Sponsored block modifications on Industry Week

### DIFF
--- a/tenants/industryweek/templates/continuous-improvements.marko
+++ b/tenants/industryweek/templates/continuous-improvements.marko
@@ -1,4 +1,6 @@
 import emailX from "../config/email-x";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
@@ -21,6 +23,14 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,17 +49,111 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74417
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <!-- Section Query Wrapper -->
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 74417,
+            queryFragment: contentList,
+          }>
+            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+              <tr>
+                <td valign="top">
+                  $ const tableWidth = 700;
+                  $ const innerPadding = 20;
+                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
+                  <for|node, index| of=nodes>
+                    <if(node.primaryImage)>
+                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
+                        <tr>
+                          <td style="padding-left: 20px;">
+                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
+                              $!{getSponsoredByText(node, 'Advertisement')}
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                              <tr>
+                                <td>
+                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                    <marko-newsletter-imgix
+                                      src=image.src
+                                      alt=image.alt
+                                      options={ w: 180 }
+                                      class="main"
+                                      attrs={ border: 0, width: 180 }
+                                    >
+                                      <@link href=node.siteContext.url target="_blank" />
+                                    </marko-newsletter-imgix>
+                                  </marko-core-obj-value>
+                                </td>
+                              </tr>
+                            </common-table>
+                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                              <tr>
+                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                </td>
+                              </tr>
+                              <if(node.linkText)>
+                                <tr>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                    <common-table align="center" padding=0 spacing=0>
+                                      <tr>
+                                        <td style=`${buttonStyle}`>
+                                          <marko-core-text value=node.linkText>
+                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                          </marko-core-text>
+                                          </td>
+                                        </tr>
+                                    </common-table>
+                                  </td>
+                                </tr>
+                              </if>
+                            </common-table>
+                          </td>
+                        </tr>
+                      </common-table>
+                    </if>
+                    <else>
+                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                        <tr>
+                          <td style=`padding: ${innerPadding}px;`>
+                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                            <if(node.linkText)>
+                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
+                                <tr>
+                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                    <common-table align="center" padding=0 spacing=0>
+                                      <tr>
+                                        <td style=`${buttonStyle}`>
+                                          <marko-core-text value=node.linkText>
+                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
+                                          </marko-core-text>
+                                          </td>
+                                        </tr>
+                                    </common-table>
+                                  </td>
+                                </tr>
+                              </common-table>
+                            </if>
+                          </td>
+                        </tr>
+                      </common-table>
+                    </else>
+                  </for>
+                </td>
+              </tr>
+            </common-table>
+          </marko-web-query>
+        </td>
+      </tr>
+    </common-table>
 
     <common-style-a-section-spacer-block />
 
@@ -65,6 +169,8 @@ $ const buttonTextStyle = {
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
+
+    <common-style-a-section-spacer-block />
 
     <common-style-a-card-section-wrapper-block
       section-id=74419

--- a/tenants/industryweek/templates/quick-manufacturing-news.marko
+++ b/tenants/industryweek/templates/quick-manufacturing-news.marko
@@ -102,16 +102,16 @@ $ const getReadMoreText = (node) => {
                         </tr>
                         <tr>
                           <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                     <marko-newsletter-imgix
                                       src=image.src
                                       alt=image.alt
-                                      options={ w: 260 }
+                                      options={ w: 180 }
                                       class="main"
-                                      attrs={ border: 0, width: 260 }
+                                      attrs={ border: 0, width: 180 }
                                     >
                                       <@link href=node.siteContext.url target="_blank" />
                                     </marko-newsletter-imgix>
@@ -119,15 +119,15 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
                               <if(node.linkText)>
                                 <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>
@@ -158,7 +158,7 @@ $ const getReadMoreText = (node) => {
                                       <tr>
                                         <td style=`${buttonStyle}`>
                                           <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
                                           </marko-core-text>
                                           </td>
                                         </tr>
@@ -171,6 +171,15 @@ $ const getReadMoreText = (node) => {
                         </tr>
                       </common-table>
                     </else>
+                    <if(!isLast(nodes, index))>
+                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                        <tr>
+                          <td valign="top">
+                            <hr style="margin:0;">
+                          </td>
+                        </tr>
+                      </common-table>
+                    </if>
                   </for>
                 </td>
               </tr>
@@ -220,8 +229,8 @@ $ const getReadMoreText = (node) => {
                           </td>
                         </tr>
                         <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
@@ -238,19 +247,18 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                                     <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                                   </marko-core-obj-text>
-                                  <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
                                   <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
                               <if(node.linkText)>
                                 <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>
@@ -275,12 +283,12 @@ $ const getReadMoreText = (node) => {
                             <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                             </marko-core-obj-text>
-                            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+
                             <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                             <if(node.linkText)>
                               <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
                                 <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>
@@ -356,8 +364,8 @@ $ const getReadMoreText = (node) => {
                           </td>
                         </tr>
                         <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
@@ -374,13 +382,12 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="righ" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                                     <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                                   </marko-core-obj-text>
-                                  <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
                                   <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
@@ -411,12 +418,12 @@ $ const getReadMoreText = (node) => {
                             <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                             </marko-core-obj-text>
-                            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+
                             <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                             <if(node.linkText)>
                               <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
                                 <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>
@@ -492,8 +499,8 @@ $ const getReadMoreText = (node) => {
                           </td>
                         </tr>
                         <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
@@ -510,13 +517,13 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
                                   <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                                     <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                                   </marko-core-obj-text>
-                                  <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+
                                   <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
@@ -547,12 +554,12 @@ $ const getReadMoreText = (node) => {
                             <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                             </marko-core-obj-text>
-                            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+
                             <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                             <if(node.linkText)>
                               <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
                                 <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>
@@ -618,16 +625,16 @@ $ const getReadMoreText = (node) => {
                         </tr>
                         <tr>
                           <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                     <marko-newsletter-imgix
                                       src=image.src
                                       alt=image.alt
-                                      options={ w: 260 }
+                                      options={ w: 180 }
                                       class="main"
-                                      attrs={ border: 0, width: 260 }
+                                      attrs={ border: 0, width: 180 }
                                     >
                                       <@link href=node.siteContext.url target="_blank" />
                                     </marko-newsletter-imgix>
@@ -635,15 +642,15 @@ $ const getReadMoreText = (node) => {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
                               <if(node.linkText)>
                                 <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
                                     <common-table align="center" padding=0 spacing=0>
                                       <tr>
                                         <td style=`${buttonStyle}`>

--- a/tenants/industryweek/templates/supply-chain-insights.marko
+++ b/tenants/industryweek/templates/supply-chain-insights.marko
@@ -78,16 +78,16 @@ $ const teaserStyle = {
                         </tr>
                         <tr>
                           <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
                               <tr>
                                 <td>
                                   <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
                                     <marko-newsletter-imgix
                                       src=image.src
                                       alt=image.alt
-                                      options={ w: 260 }
+                                      options={ w: 180 }
                                       class="main"
-                                      attrs={ border: 0, width: 260 }
+                                      attrs={ border: 0, width: 180 }
                                     >
                                       <@link href=node.siteContext.url target="_blank" />
                                     </marko-newsletter-imgix>
@@ -95,13 +95,9 @@ $ const teaserStyle = {
                                 </td>
                               </tr>
                             </common-table>
-                            <common-table width=410 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
                                 <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                                  </marko-core-obj-text>
-                                  <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
                                   <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                                 </td>
                               </tr>
@@ -129,10 +125,6 @@ $ const teaserStyle = {
                       <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                         <tr>
                           <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
                             <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
                             <if(node.linkText)>
                               <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>


### PR DESCRIPTION
Image size for sponsored/editorial advertisements down to 180, spacing adjusted to compensate for smaller image.

On QMN, images moved to the left for editorial content, and on the right for advertisements.

I think they’re restructuring their newsletters in the next round of changes, so I’m holding off on templatizing these tweaks until we know for sure what they’re sticking with.
![Screen Shot 2019-12-23 at 9 43 16 AM](https://user-images.githubusercontent.com/12496550/71370215-d6e43180-2572-11ea-8845-0ecbb4486eb1.png)


![image](https://user-images.githubusercontent.com/12496550/71370249-f9764a80-2572-11ea-9e9a-3e097ccfdcc2.png)

