### PR TITLE
Switch “Product Alert” Template

### DIFF
--- a/tenants/ewweb/templates/product-alert.marko
+++ b/tenants/ewweb/templates/product-alert.marko
@@ -39,7 +39,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73079
       title="EW's Top 10 LED Picks"
       date=date
@@ -54,7 +54,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73080
       title="Rep News"
       date=date
@@ -69,7 +69,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73081
       title="Buying/Marketing Groups"
       date=date
@@ -84,7 +84,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73082
       title="EW Podcast"
       date=date
@@ -99,7 +99,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73083
       title="Top 200"
       date=date
@@ -114,7 +114,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73084
       title="Wow! $99 Subscriptions to Electrical Marketing Newsletter"
       date=date
@@ -129,7 +129,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73085
       title="E-Book"
       date=date
@@ -144,7 +144,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73086
       title="People on the Move"
       date=date
@@ -159,7 +159,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73087
       title="NE Code"
       date=date
@@ -174,7 +174,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=73088
       title="Quotes to Remember"
       date=date


### PR DESCRIPTION
Swapped it out from the card layout to a full-width style with 180w images.

![Screen Shot 2020-01-03 at 8 17 52 AM](https://user-images.githubusercontent.com/12496550/71728266-3c9dac80-2e02-11ea-85af-9dc921c82431.png)
