### PR TITLE
Color update for Fleet Owner Webinars/Whitepaper eNL

### DIFF
--- a/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
@@ -34,12 +34,12 @@ $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const contentLinkStyle = {
   "font-weight": "bold",
-  "color": "#0190ba",
+  "color": "#0a2536",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 };
-$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0190ba;";
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0a2536;";
 $ const buttonTextStyle = {
   "color": "#ffffff",
   "font-family": "Helvetica, Arial, sans-serif",
@@ -69,13 +69,13 @@ $ const buttonTextStyle = {
     <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=74557
       date=date
-      limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
@@ -34,12 +34,12 @@ $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif
 $ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const contentLinkStyle = {
   "font-weight": "bold",
-  "color": "#0190ba",
+  "color": "#0a2536",
   "font-size": "19.5px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 };
-$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0190ba;";
+$ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #0a2536;";
 $ const buttonTextStyle = {
   "color": "#ffffff",
   "font-family": "Helvetica, Arial, sans-serif",
@@ -69,13 +69,13 @@ $ const buttonTextStyle = {
     <common-style-a-product-spotlight-180-section-wrapper-block
       section-id=74558
       date=date
-      limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />


### PR DESCRIPTION
- Dark gray background on content removed
- Title color updated to match header
- Limit of 1 removed

**After:**
![Screen Shot 2020-01-07 at 7 49 45 AM](https://user-images.githubusercontent.com/12496550/71900327-3d488280-3123-11ea-9391-93b3fe210da7.png)

**Before:**
![Screen Shot 2020-01-07 at 7 49 51 AM](https://user-images.githubusercontent.com/12496550/71900321-39b4fb80-3123-11ea-8b55-31e8c26691ea.png)
