### PR TITLE
New block for informa digital editions

### DIFF
--- a/packages/common/components/style-a/blocks/image-title-body-wrapper.marko
+++ b/packages/common/components/style-a/blocks/image-title-body-wrapper.marko
@@ -1,0 +1,77 @@
+import isLast from "@endeavor-business-media/common/utils/is-last";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  newsletter,
+  date,
+  sectionId,
+  title,
+  limit,
+  skip,
+  teaserStyle,
+  promotionStyle
+} = input;
+$ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
+$ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
+$ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "font-weight": "bold",
+  "color": "#00b398",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+});
+
+<common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+  <tr>
+    <td>
+      <!-- Section Query Wrapper -->
+      <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+        date: date.valueOf(),
+        newsletterId: newsletter.id,
+        sectionId: sectionId,
+        limit: limit,
+        skip: skip,
+        queryFragment: contentList,
+      }>
+        <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+          <if(title)>
+            <tr>
+              <td>
+                <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>
+                      <h3 style=`${titleStyle}`>${title}</h3>
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+          </if>
+          <tr>
+            <td valign="top">
+              <for|node, index| of=nodes>
+                <common-style-a-image-title-body-block
+                  node=node
+                  content-link-style=contentLinkStyle
+                  teaser-style=teaserStyle
+                  promotion-style=promotionStyle
+                />
+                <if(!isLast(nodes, index))>
+                  <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                    <tr>
+                      <td valign="top">
+                        <hr style="margin:0;">
+                      </td>
+                    </tr>
+                  </common-table>
+                </if>
+            </for>
+            </td>
+          </tr>
+        </common-table>
+      </marko-web-query>
+    </td>
+  </tr>
+</common-table>

--- a/packages/common/components/style-a/blocks/image-title-body.marko
+++ b/packages/common/components/style-a/blocks/image-title-body.marko
@@ -1,0 +1,111 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  node,
+  alignment,
+  tableWidth,
+  imgWidth,
+} = input;
+$ const teaserStyle = defaultValue(input.teaserStyle, {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+});
+$ const promotionStyle = defaultValue(input.promotionStyle, {
+  "font-size": "18px",
+  "line-height": "26px",
+  "margin": "0",
+  "padding-top": "10",
+  "color": "#222 !important",
+  "text-decoration": "none !important",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+});
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "text-align": "left",
+  "text-decoration": "none !important",
+  "font-size": "14px",
+  "line-height": "24px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#00B39E",
+  "font-weight": "bold"
+});
+
+$ const innerPadding = "20px 30px 20px 15px";
+
+<if(node.primaryImage)>
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: 0; padding-left: 20px; padding-bottom: 20px;`>
+        <common-table width=250 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>
+              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                <marko-newsletter-imgix
+                  src=image.src
+                  alt=image.alt
+                  options={ w: imgWidth }
+                  class="main"
+                  attrs={ border: 0, width: imgWidth }
+                >
+                  <@link href=node.siteContext.url target="_blank" />
+                </marko-newsletter-imgix>
+              </marko-core-obj-value>
+            </td>
+          </tr>
+        </common-table>
+        <common-table width=420 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
+          <if(node.type !== "promotion")>
+            <tr>
+              <td style=`padding: 20px 20px 5px 20px;`>
+                <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                  <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                </marko-core-obj-text>
+              </td>
+            </tr>
+          </if>
+          <tr>
+            <td style='padding: 0px 20px 10px 20px;'>
+              <if(node.type === "promotion")>
+                <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: promotionStyle } />
+              </if>
+              <else>
+                <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              </else>
+            </td>
+          </tr>
+
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+</if>
+<else>
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+    <if(node.type !== "promotion")>
+      <tr>
+        <td style=`padding: 20px 20px 5px 20px;`>
+          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+          </marko-core-obj-text>
+        </td>
+      </tr>
+    </if>
+    <tr>
+      <td style='padding: 0px 20px 20px 20px;'>
+        <if(node.type === "promotion")>
+          <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: promotionStyle } />
+        </if>
+        <else>
+          <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+        </else>
+      </td>
+    </tr>
+
+  </common-table>
+</else>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -165,6 +165,36 @@
     "@main-table-style": "string",
     "@content-link-style": "object"
   },
+  "<common-style-a-image-title-body-wrapper-block>": {
+    "template": "./image-title-body-wrapper.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@title": "string",
+    "@title-table-style": "string",
+    "@title-style": "string",
+    "@promotion-style": "object",
+    "@teaser-style": "object",
+    "@main-table-style": "string",
+    "@content-link-style": "object"
+  },
   "<common-style-a-product-spotlight-180-section-wrapper-block>": {
     "template": "./product-spotlight-180-section-wrapper.marko",
     "@date": {
@@ -351,6 +381,25 @@
     "@teaser-style": "object",
     "@button-style": "string",
     "@button-text-style": "object"
+  },
+  "<common-style-a-image-title-body-block>": {
+    "template": "./image-title-body.marko",
+    "@node": "object",
+    "@alignment": {
+      "type": "string",
+      "default-value": "left"
+    },
+    "@table-width": {
+      "type": "number",
+      "default-value": 700
+    },
+    "@img-width": {
+      "type": "number",
+      "default-value": 240
+    },
+    "@content-link-style": "object",
+    "@teaser-style": "object",
+    "@promotion-style": "object"
   },
   "<common-style-a-product-spotlight-180-block>": {
     "template": "./product-spotlight-180.marko",

--- a/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
+++ b/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
@@ -104,7 +104,7 @@ $ const innerPadding = 20;
         <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
           <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
         </marko-core-obj-text>
-        <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+        <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp;</div>
         <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
         <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>

--- a/tenants/trucker/templates/digital-edition.marko
+++ b/tenants/trucker/templates/digital-edition.marko
@@ -1,0 +1,50 @@
+import emailX from "../config/email-x";
+
+$ const { newsletter, date } = data;
+$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
+$ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
+$ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #ccc; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00464f; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00464f;";
+$ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
+$ const mainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "font-weight": "bold",
+  "color": "#78272e",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-a-styles />
+  </@head>
+  <@body style="margin: 0px !important; background-color: #efefef;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+    <tenant-header-block image-path="/files/base/ebm/trucker/image/static/newsletters/digital_edition_header.jpg" date=date newsletter=newsletter />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-image-title-body-wrapper-block
+      section-id=80765
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-opt-out-block />
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
<img width="677" alt="Screen Shot 2020-01-07 at 4 38 58 PM" src="https://user-images.githubusercontent.com/12496550/71935593-cd5eea00-316c-11ea-8217-bce05ff7fb5c.png">
Promotions will just display body and everything else will have image/title/teaser

Legacy: http://enewspro.penton.com/pentonenews/americantrucker/AT-04/20191017_AT-04_27/display