### PR TITLE
160w right-rail template for Promotions

### DIFF
--- a/packages/common/components/style-a/blocks/left-two-thirds-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/left-two-thirds-section-wrapper.marko
@@ -1,0 +1,216 @@
+import isLast from "@endeavor-business-media/common/utils/is-last";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
+
+$ const {
+  newsletter,
+  date,
+  sectionId,
+  title,
+  limit,
+  skip,
+  buttonStyle,
+  buttonTextStyle,
+  teaserStyle
+} = input;
+$ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
+$ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
+$ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "font-weight": "bold",
+  "color": "#00b398",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+});
+$ const getReadMoreText = (node) => {
+  const { type, typeTitle } = node;
+  const viewType = ["video", "photo-gallery", "whitepaper"];
+  return viewType.includes(type) ? node.typeTitle : `Full ${node.typeTitle}`;
+};
+$ const innerPadding = 20;
+
+$ const imgWidth = 180;
+
+<common-table width="480" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+  <tr>
+    <td>
+      <!-- Section Query Wrapper -->
+      <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+        date: date.valueOf(),
+        newsletterId: newsletter.id,
+        sectionId: sectionId,
+        limit: limit,
+        skip: skip,
+        queryFragment: contentList,
+      }>
+        <common-table width="480" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+          <tr>
+            <td>
+              <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
+                <tr>
+                  <td>
+                    <h3 style=`${titleStyle}`>${title}</h3>
+                  </td>
+                </tr>
+              </common-table>
+            </td>
+          </tr>
+          <tr>
+            <td valign="top">
+              <for|node, index| of=nodes>
+                <if(node.type === "promotion")>
+                  <common-table width=200 style="border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                    <tr>
+                      <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                        <common-table width=200 style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
+                          <tr>
+                            <td>
+                              <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
+                                $!{getSponsoredByText(node, 'Advertisement')}
+                              </div>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td>&nbsp;</td>
+                          </tr>
+                          <tr>
+                            <td>
+                              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                <marko-newsletter-imgix
+                                  src=image.src
+                                  alt=image.alt
+                                  options={ w: imgWidth }
+                                  class="main"
+                                  attrs={ border: 0, width: imgWidth }
+                                >
+                                  <@link href=node.siteContext.url target="_blank" />
+                                </marko-newsletter-imgix>
+                              </marko-core-obj-value>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td>&nbsp;</td>
+                          </tr>
+                        </common-table>
+                      </td>
+                    </tr>
+                  </common-table>
+
+                  <common-table width=200 style="border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
+                    <tr>
+                      <td style=`padding: 0; padding-right: 25px; padding-bottom: ${innerPadding}px;`>
+                        <common-table width=200 style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+
+                          <tr>
+                            <td>
+                              <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
+                            </td>
+                          </tr>
+                          <tr>
+                            <td>&nbsp;</td>
+                          </tr>
+                        </common-table>
+                      </td>
+                    </tr>
+                  </common-table>
+                </if>
+                <else>
+                  <if(node.primaryImage)>
+                    <common-table width=480 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                      <tr>
+                        <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                          <common-table width=160 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
+                            <tr>
+                              <td>
+                                <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
+                                  $!{getSponsoredByText(node, '&nbsp;')}
+                                </div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                  <marko-newsletter-imgix
+                                    src=image.src
+                                    alt=image.alt
+                                    options={ w: 160 }
+                                    class="main"
+                                    attrs={ border: 0, width: 160 }
+                                  >
+                                    <@link href=node.siteContext.url target="_blank" />
+                                  </marko-newsletter-imgix>
+                                </marko-core-obj-value>
+                              </td>
+                            </tr>
+                          </common-table>
+                          <common-table width=250 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
+                            <tr>
+                              <td style=`padding: ${innerPadding}px;`>
+                                <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                                  <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                                </marko-core-obj-text>
+                                <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                              </td>
+                            </tr>
+                            <tr>
+                              <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+                                <common-table align="center" padding=0 spacing=0>
+                                  <tr>
+                                    <td style=`${buttonStyle}`>
+                                      <marko-core-text value=getReadMoreText(node)>
+                                        <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                      </marko-core-text>
+                                      </td>
+                                    </tr>
+                                </common-table>
+                              </td>
+                            </tr>
+                          </common-table>
+                        </td>
+                      </tr>
+                    </common-table>
+                  </if>
+                  <else>
+                    <common-table width=480 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+                      <tr>
+                        <td style=`padding: ${innerPadding}px;`>
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
+                          <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+
+                          <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
+                            <tr>
+                              <td style=`${buttonStyle}`>
+                                <marko-core-text value=getReadMoreText(node)>
+                                  <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                </marko-core-text>
+                                </td>
+                              </tr>
+                          </common-table>
+                        </td>
+                      </tr>
+                    </common-table>
+                  </else>
+                </else>
+
+                <if(!isLast(nodes, index))>
+                  <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                    <tr>
+                      <td valign="top">
+                        <hr style="margin:0;">
+                      </td>
+                    </tr>
+                  </common-table>
+                </if>
+            </for>
+            </td>
+          </tr>
+        </common-table>
+      </marko-web-query>
+    </td>
+  </tr>
+</common-table>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -382,6 +382,37 @@
     "@button-style": "string",
     "@button-text-style": "object"
   },
+  "<common-style-a-left-two-thirds-section-wrapper-block>": {
+    "template": "./left-two-thirds-section-wrapper.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@title": "string",
+    "@title-table-style": "string",
+    "@title-style": "string",
+    "@teaser-style": "object",
+    "@button-style": "string",
+    "@button-text-style": "object",
+    "@main-table-style": "string",
+    "@content-link-style": "object"
+  },
   "<common-style-a-image-title-body-block>": {
     "template": "./image-title-body.marko",
     "@node": "object",

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -1,4 +1,5 @@
 import emailX from "../config/email-x";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
@@ -11,6 +12,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #00748d;";
 $ const buttonTextStyle = {
@@ -21,15 +23,23 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
+
+$ const imgWidth = 160;
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,64 +47,132 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" align="left">
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74435
-      title="Editor's Choice"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74435
+            title="Editor's Choice"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-list-section-wrapper-block
-      section-id=74436
-      title="Last Weeks Top 3 Stories"
-      limit=3
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <!-- <common-style-a-list-section-wrapper-block
+            section-id=74436
+            title="Last Weeks Top 3 Stories"
+            limit=3
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+          /> -->
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74437
-      title="Webinars"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74437
+            title="Webinars"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74438
-      title="Whitepapers"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74438
+            title="Whitepapers"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+
+        </td>
+
+        <td width="200" align="center" valign="top">
+
+          <common-style-a-section-spacer-block />
+
+
+            <common-table width="180" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
+              <tr>
+                <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+
+                  <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+                    date: date.valueOf(),
+                    newsletterId: newsletter.id,
+                    sectionId: 80766,
+                    queryFragment: contentList,
+                  }>
+
+                  <for|node| of=nodes>
+
+                    <common-table width="180" style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class=`right` padding=0 spacing=0>
+                      <tr>
+                        <td>
+                          <h3 style="margin:0;font-weight:normal;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                            Advertisement
+                          </h3>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="center">
+                          <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                            <marko-newsletter-imgix
+                              src=image.src
+                              alt=image.alt
+                              options={ w: imgWidth }
+                              class="main"
+                              attrs={ border: 0, width: imgWidth }
+                            >
+                              <@link href=node.siteContext.url target="_blank" />
+                            </marko-newsletter-imgix>
+                          </marko-core-obj-value>
+                          <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </common-table>
+                  </for>
+
+                  </marko-web-query>
+
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+
+        </td>
+    </tr>
+
+    </common-table>
 
     <common-style-a-section-spacer-block />
 


### PR DESCRIPTION
Allows Promotions to be scheduled to the right-side of newsletters, similar to the “skyscraper” ad that’s run through EmailX, only this allows for text below the image.  Added new “left-two-thirds-section-wrapper” for the left-hand side of the newsletter (reduced table width and font sizes)

<img width="678" alt="Screen Shot 2020-01-08 at 4 22 50 PM" src="https://user-images.githubusercontent.com/12496550/72022269-9f91a800-3235-11ea-8ba5-b0f81dc8ac4f.png">
