### PR TITLE
TableWidth variable added to “list-section-wrapper”

### DIFF
--- a/packages/common/components/style-a/blocks/list-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/list-section-wrapper.marko
@@ -23,7 +23,9 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 });
 
-<common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+$ const tableWidth = defaultValue(input.tableWidth, "700");
+
+<common-table width=tableWidth style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
   <tr>
     <td>
       <!-- Section Query Wrapper -->
@@ -34,7 +36,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
         limit: limit,
         queryFragment: contentList,
       }>
-        <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+        <common-table width=tableWidth style=mainTableStyle align="left" class="main" padding=0 spacing=0>
           <if(title)>
             <tr>
               <td>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -291,6 +291,7 @@
     "@title-table-style": "string",
     "@title-style": "string",
     "@main-table-style": "string",
+    "@table-width": "string",
     "@content-link-style": "object"
   },
   "<common-style-a-title-teaser-block>": {

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -68,7 +68,7 @@ $ const imgWidth = 160;
 
           <common-style-a-section-spacer-block />
 
-          <!-- <common-style-a-list-section-wrapper-block
+          <common-style-a-list-section-wrapper-block
             section-id=74436
             title="Last Weeks Top 3 Stories"
             limit=3
@@ -76,9 +76,10 @@ $ const imgWidth = 160;
             newsletter=newsletter
             title-table-style=titleTableStyle
             title-style=titleStyle
+            table-width="480"
             main-table-style=mainTableStyle
             content-link-style=contentLinkStyle
-          /> -->
+          />
 
           <common-style-a-section-spacer-block />
 


### PR DESCRIPTION
Allows the list style table to be modifiable for the skyscraper ads on the right.  Default is 700, overrode it to 480 for Products of the Week for one of their sections
![Screen Shot 2020-01-09 at 7 28 26 AM](https://user-images.githubusercontent.com/12496550/72071668-f50b9a80-32b1-11ea-8a89-1d3627979d18.png)

