### PR TITLE
Alignment variable to “list-section-wrapper” block

### DIFF
--- a/packages/common/components/style-a/blocks/list-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/list-section-wrapper.marko
@@ -23,9 +23,10 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
 });
 
+$ const alignment = defaultValue(input.alignment, "center");
 $ const tableWidth = defaultValue(input.tableWidth, "700");
 
-<common-table width=tableWidth style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+<common-table width=tableWidth style="border-collapse:collapse;" align=alignment class="main" padding=0 spacing=0>
   <tr>
     <td>
       <!-- Section Query Wrapper -->
@@ -36,7 +37,7 @@ $ const tableWidth = defaultValue(input.tableWidth, "700");
         limit: limit,
         queryFragment: contentList,
       }>
-        <common-table width=tableWidth style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+        <common-table width=tableWidth style=mainTableStyle align=alignment class="main" padding=0 spacing=0>
           <if(title)>
             <tr>
               <td>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -292,6 +292,7 @@
     "@title-style": "string",
     "@main-table-style": "string",
     "@table-width": "string",
+    "@alignment": "string",
     "@content-link-style": "object"
   },
   "<common-style-a-title-teaser-block>": {

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -77,6 +77,7 @@ $ const imgWidth = 160;
             title-table-style=titleTableStyle
             title-style=titleStyle
             table-width="480"
+            alignment="left"
             main-table-style=mainTableStyle
             content-link-style=contentLinkStyle
           />


### PR DESCRIPTION
When used for the smaller tables with the skyscraper on the right (Like products of the week) the table should be left-aligned.  For everything else, it should be centered, so I set “center” as the default then overrode it for Product of the Week.

![Screen Shot 2020-01-09 at 11 24 25 AM](https://user-images.githubusercontent.com/12496550/72090892-84c24080-32d4-11ea-8675-814f1828a3f4.png)
