### PR TITLE
Extended “right-rail” ad support to additional eNLs

### DIFF
--- a/packages/common/components/core-table.marko
+++ b/packages/common/components/core-table.marko
@@ -11,6 +11,7 @@ $ const padding = input.padding === null ? null : defaultValue(input.padding, 0)
   border=border
   cellpadding=padding
   cellspacing=spacing
+  valign=input.valign
   align=input.align
   style=input.style
 >

--- a/packages/common/components/marko.json
+++ b/packages/common/components/marko.json
@@ -13,6 +13,7 @@
     "@class": "string",
     "@spacing": "number",
     "@padding": "number",
+    "@valign": "string",
     "@align": "string",
     "@style": "string",
     "@attrs": "object"

--- a/packages/common/components/style-a/blocks/left-two-thirds-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/left-two-thirds-section-wrapper.marko
@@ -121,7 +121,7 @@ $ const imgWidth = 180;
                     <common-table width=480 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                       <tr>
                         <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                          <common-table width=160 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
+                          <common-table width=180 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
                             <tr>
                               <td>
                                 <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
@@ -135,9 +135,9 @@ $ const imgWidth = 180;
                                   <marko-newsletter-imgix
                                     src=image.src
                                     alt=image.alt
-                                    options={ w: 160 }
+                                    options={ w: 180 }
                                     class="main"
-                                    attrs={ border: 0, width: 160 }
+                                    attrs={ border: 0, width: 180 }
                                   >
                                     <@link href=node.siteContext.url target="_blank" />
                                   </marko-newsletter-imgix>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -295,6 +295,31 @@
     "@alignment": "string",
     "@content-link-style": "object"
   },
+  "<common-style-a-right-rail-block>": {
+    "template": "./right-rail.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@teaser-style": "object",
+    "@main-table-style": "string"
+  },
   "<common-style-a-title-teaser-block>": {
     "template": "./title-teaser.marko",
     "@date": {

--- a/packages/common/components/style-a/blocks/right-rail.marko
+++ b/packages/common/components/style-a/blocks/right-rail.marko
@@ -1,0 +1,68 @@
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  newsletter,
+  date,
+  sectionId,
+  limit,
+  skip,
+  teaserStyle
+} = input;
+$ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
+$ const imgWidth = 160;
+
+
+<common-table width="180" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
+  <tr>
+    <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+
+      <!-- Section Query Wrapper -->
+      <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+        date: date.valueOf(),
+        newsletterId: newsletter.id,
+        sectionId: sectionId,
+        limit: limit,
+        queryFragment: contentList,
+      }>
+
+      <for|node| of=nodes>
+
+        <common-table width="180" style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class=`right` padding=0 spacing=0>
+          <tr>
+            <td>
+              <h3 style="margin:0;font-weight:normal;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                Advertisement
+              </h3>
+            </td>
+          </tr>
+          <tr>
+            <td align="center">
+              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                <marko-newsletter-imgix
+                  src=image.src
+                  alt=image.alt
+                  options={ w: imgWidth }
+                  class="main"
+                  attrs={ border: 0, width: imgWidth }
+                >
+                  <@link href=node.siteContext.url target="_blank" />
+                </marko-newsletter-imgix>
+              </marko-core-obj-value>
+              <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
+            </td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+        </common-table>
+      </for>
+
+      </marko-web-query>
+
+    </td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+  </tr>
+</common-table>

--- a/tenants/bulktransporter/templates/bulk-logistics-trends.marko
+++ b/tenants/bulktransporter/templates/bulk-logistics-trends.marko
@@ -12,6 +12,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #5e1d5a;";
 $ const buttonTextStyle = {

--- a/tenants/ehstoday/templates/construction-safety.marko
+++ b/tenants/ehstoday/templates/construction-safety.marko
@@ -11,6 +11,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #005844;";
 $ const buttonTextStyle = {
@@ -21,15 +22,23 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
+
+$ const imgWidth = 160;
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,19 +46,41 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" valign="top" align="left">
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74506
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74506
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+
+        </td>
+
+        <td width="200" align="center" valign="top">
+
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-right-rail-block
+            section-id=80770
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+        </td>
+      </tr>
+
+    </common-table>
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/management.marko
+++ b/tenants/ehstoday/templates/management.marko
@@ -11,6 +11,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #005844;";
 $ const buttonTextStyle = {
@@ -21,15 +22,21 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,19 +44,41 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" valign="top" align="left">
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74533
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74533
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+
+        </td>
+
+        <td width="200" align="center" valign="top">
+
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-right-rail-block
+            section-id=80771
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+        </td>
+      </tr>
+
+    </common-table>
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/safety-tech-analytics-news.marko
+++ b/tenants/ehstoday/templates/safety-tech-analytics-news.marko
@@ -11,6 +11,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #005844;";
 $ const buttonTextStyle = {
@@ -21,15 +22,21 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,19 +44,41 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" valign="top" align="left">
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74446
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74446
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+
+        </td>
+
+        <td width="200" align="center" valign="top">
+
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-right-rail-block
+            section-id=80769
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+        </td>
+      </tr>
+
+    </common-table>
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/weekly-update.marko
+++ b/tenants/ehstoday/templates/weekly-update.marko
@@ -11,6 +11,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #005844;";
 $ const buttonTextStyle = {
@@ -21,15 +22,21 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,19 +44,41 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" valign="top" align="left">
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74416
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74416
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+
+        </td>
+
+        <td width="200" align="center" valign="top">
+
+          <common-style-a-section-spacer-block />
+
+          <common-style-a-right-rail-block
+            section-id=80768
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+        </td>
+      </tr>
+
+    </common-table>
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/mhlnews/templates/newsmakers.marko
+++ b/tenants/mhlnews/templates/newsmakers.marko
@@ -1,4 +1,5 @@
 import emailX from "../config/email-x";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
@@ -11,6 +12,7 @@ $ const contentLinkStyle = {
   "font-size": "16px",
   "line-height": "20px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #00748d;";
 $ const buttonTextStyle = {
@@ -21,15 +23,23 @@ $ const buttonTextStyle = {
   "text-decoration": "none",
   "text-transform": "uppercase"
 };
+$ const teaserStyle = {
+  "font-size": "12px",
+  "line-height": "146%",
+  "margin": "0",
+  "padding": "0",
+  "color": "#000000",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
+};
+
+$ const imgWidth = 160;
 
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
   date=date
 >
-  <@head>
-    <common-style-a-styles />
-  </@head>
+
   <@body style="margin: 0px !important; background-color: #efefef;">
     <common-banner-element
       name=newsletter.name
@@ -37,98 +47,121 @@ $ const buttonTextStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-style-a-section-spacer-block />
+    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td width="500" valign="top" align="left">
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74439
-      title="Spotlight"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74439
+            title="Spotlight"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74440
-      title="Industry News"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74440
+            title="Industry News"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74441
-      title="Commentary & Analysis"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74441
+            title="Commentary & Analysis"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-list-section-wrapper-block
-      section-id=74442
-      title="Last Weeks Top 3 Stories"
-      limit=3
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-list-section-wrapper-block
+            section-id=74442
+            title="Last Weeks Top 3 Stories"
+            limit=3
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            alignment="left"
+            table-width="480"
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+          />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74443
-      title="Webinars"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74443
+            title="Webinars"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
 
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74444
-      title="Whitepapers"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
+          <common-style-a-section-spacer-block />
 
-    <common-style-a-section-spacer-block />
+          <common-style-a-left-two-thirds-section-wrapper-block
+            section-id=74444
+            title="Whitepapers"
+            date=date
+            newsletter=newsletter
+            title-table-style=titleTableStyle
+            title-style=titleStyle
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+          />
+          </td>
 
-    <common-style-a-opt-out-block />
+          <td width="200" align="center" valign="top">
+
+            <common-style-a-section-spacer-block />
+
+            <common-style-a-right-rail-block
+              section-id=80767
+              date=date
+              newsletter=newsletter
+              main-table-style=mainTableStyle
+            />
+
+          </td>
+        </tr>
+
+      </common-table>
+
+      <common-style-a-section-spacer-block />
+
+      <common-style-a-opt-out-block />
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -49,7 +49,7 @@ $ const imgWidth = 160;
 
     <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
-        <td width="500" align="left">
+        <td width="500" valign="top" align="left">
 
           <common-style-a-section-spacer-block />
 
@@ -118,58 +118,12 @@ $ const imgWidth = 160;
 
           <common-style-a-section-spacer-block />
 
-
-            <common-table width="180" style="border-collapse:collapse; background-color: #ffffff;" align="center" class="main" padding=0 spacing=0>
-              <tr>
-                <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
-
-                  <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-                    date: date.valueOf(),
-                    newsletterId: newsletter.id,
-                    sectionId: 80766,
-                    queryFragment: contentList,
-                  }>
-
-                  <for|node| of=nodes>
-
-                    <common-table width="180" style=`border-collapse:collapse;  mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class=`right` padding=0 spacing=0>
-                      <tr>
-                        <td>
-                          <h3 style="margin:0;font-weight:normal;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
-                            Advertisement
-                          </h3>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td align="center">
-                          <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                            <marko-newsletter-imgix
-                              src=image.src
-                              alt=image.alt
-                              options={ w: imgWidth }
-                              class="main"
-                              attrs={ border: 0, width: imgWidth }
-                            >
-                              <@link href=node.siteContext.url target="_blank" />
-                            </marko-newsletter-imgix>
-                          </marko-core-obj-value>
-                          <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: teaserStyle } />
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                  </for>
-
-                  </marko-web-query>
-
-                </td>
-              </tr>
-              <tr>
-                <td>&nbsp;</td>
-              </tr>
-            </common-table>
+          <common-style-a-right-rail-block
+            section-id=80766
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
 
         </td>
     </tr>

--- a/tenants/refrigeratedtransporter/templates/business-picture.marko
+++ b/tenants/refrigeratedtransporter/templates/business-picture.marko
@@ -21,6 +21,7 @@ $ const buttonTextStyle = {
   "font-weight": "bold",
   "text-decoration": "none",
   "text-transform": "uppercase"
+  "text-decoration": "none !important"
 };
 
 <marko-newsletter-root

--- a/tenants/trailerbodybuilders/templates/market-watch.marko
+++ b/tenants/trailerbodybuilders/templates/market-watch.marko
@@ -12,6 +12,7 @@ $ const contentLinkStyle = {
   "font-size": "14px",
   "line-height": "16px",
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+  "text-decoration": "none !important"
 };
 $ const buttonStyle = "font-family: Garamond, serif; font-size: 12px; line-height: 14px; border-spacing: 0; padding: 5px 10px; table-layout: fixed; background-color: #003366;";
 $ const buttonTextStyle = {


### PR DESCRIPTION
Per Megan Garcia via CS-3953, these are all the newsletters she knows of that will have the 160x600 ad on the right with text.

![Screen Shot 2020-01-09 at 2 37 49 PM](https://user-images.githubusercontent.com/12496550/72104544-471fe080-32f1-11ea-8c44-6943a7893c3c.png)


Transferred that support into a component for reuse, cleaned up e styling and added valign support to core-table.marko, otherwise the column will center vertically unless there’s enough content on the left to exceed the height of the ad on the right like so:
![Screen Shot 2020-01-09 at 2 13 31 PM](https://user-images.githubusercontent.com/12496550/72104510-32dbe380-32f1-11ea-9e53-5cb25418cead.png)
Fixed:
![Screen Shot 2020-01-09 at 2 14 00 PM](https://user-images.githubusercontent.com/12496550/72104520-37a09780-32f1-11ea-9ae4-f52d678c622d.png)


