### PR TITLE
Block layout update + new “Events” section

### DIFF
--- a/tenants/tdworld/templates/careers.marko
+++ b/tenants/tdworld/templates/careers.marko
@@ -102,6 +102,21 @@ $ const buttonTextStyle = {
     <common-style-a-section-spacer-block />
 
     <common-style-a-card-section-wrapper-block
+      section-id=80777
+      title="Events"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-style-a-section-spacer-block />
+
+    <common-style-a-card-section-wrapper-block
       section-id=73075
       title="Career Fairs"
       date=date
@@ -116,7 +131,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-title-teaser-block
       section-id=80772
       title="Job Center"
       date=date
@@ -125,8 +140,6 @@ $ const buttonTextStyle = {
       title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />


### PR DESCRIPTION
TD World’s “Careers” eNL is adding a new “Events” section, and updating the “Job Center” section to the title-teaser-block style, to mimic Energizing’s Job Center block.