### PR TITLE
UA Analytics article support

### DIFF
--- a/tenants/tdworld/templates/uai-analytics-insight.marko
+++ b/tenants/tdworld/templates/uai-analytics-insight.marko
@@ -121,9 +121,33 @@ $ const getReadMoreText = (node) => {
                             </common-table>
                             <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
+                                <if(node.type === "promotion")>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                  </td>
+                                </if>
+                                <else>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "margin-bottom": "10px", "text-align": "left" } } >
+                                      <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                                    </marko-core-obj-text>
+                                    <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                                    <common-table align="center" padding=0 spacing=0>
+                                      <tr>
+                                        <td>
+                                          &nbsp;
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td style=`${buttonStyle}`>
+                                          <marko-core-text value=getReadMoreText(node)>
+                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                          </marko-core-text>
+                                          </td>
+                                        </tr>
+                                    </common-table>
+                                  </td>
+                                </else>
                               </tr>
                               <if(node.linkText)>
                                 <tr>
@@ -240,10 +264,33 @@ $ const getReadMoreText = (node) => {
                             </common-table>
                             <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp</div>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
+                              <if(node.type === "promotion")>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                  </td>
+                                </if>
+                                <else>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "margin-bottom": "10px", "text-align": "left" } } >
+                                      <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                                    </marko-core-obj-text>
+                                    <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                                    <common-table align="center" padding=0 spacing=0>
+                                      <tr>
+                                        <td>
+                                          &nbsp;
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td style=`${buttonStyle}`>
+                                          <marko-core-text value=getReadMoreText(node)>
+                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                          </marko-core-text>
+                                          </td>
+                                        </tr>
+                                    </common-table>
+                                  </td>
+                                </else>
                               </tr>
                               <if(node.linkText)>
                                 <tr>
@@ -360,9 +407,33 @@ $ const getReadMoreText = (node) => {
                             </common-table>
                             <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
                               <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
+                                <if(node.type === "promotion")>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
+                                  </td>
+                                </if>
+                                <else>
+                                  <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
+                                    <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "margin-bottom": "10px", "text-align": "left" } } >
+                                      <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                                    </marko-core-obj-text>
+                                    <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                                    <common-table align="center" padding=0 spacing=0>
+                                      <tr>
+                                        <td>
+                                          &nbsp;
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td style=`${buttonStyle}`>
+                                          <marko-core-text value=getReadMoreText(node)>
+                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                                          </marko-core-text>
+                                          </td>
+                                        </tr>
+                                    </common-table>
+                                  </td>
+                                </else>
                               </tr>
                               <if(node.linkText)>
                                 <tr>


### PR DESCRIPTION
Built with the intent of only hosting Promotions, it didn’t account for non-promotional content.  Added support for title + teaser + CTA.

![image](https://user-images.githubusercontent.com/12496550/73194681-32fe2080-40f2-11ea-8a06-7ad0192938c5.png)
