### PR TITLE
Updated description color of ED headers

### DIFF
--- a/tenants/electronicdesign/components/blocks/header2.marko
+++ b/tenants/electronicdesign/components/blocks/header2.marko
@@ -20,7 +20,7 @@ $ const {
       <h1 style="color: #fff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
         ${newsletter.name}
       </h1>
-      <p style="color: #8c9190; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -5px 0 0 15px; font-weight: bold;">
+      <p style="color: #c7c7c7; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -5px 0 0 15px; font-weight: bold;">
         $!{newsletter.description}
       </p>
     </td>


### PR DESCRIPTION
8c9190 is really dark and hard to read on their existing headers, I think that’s just a default we pulled from TDWorld’s.  Updated to a lighter color.

![Screen Shot 2020-01-27 at 1 25 34 PM](https://user-images.githubusercontent.com/12496550/73206744-1a4d3500-4109-11ea-8cf9-37e779f2b7de.png)
