### PR TITLE
Additional 160x600 ad units

### DIFF
--- a/tenants/bulktransporter/config/email-x.js
+++ b/tenants/bulktransporter/config/email-x.js
@@ -15,5 +15,17 @@ config
       width: 160,
       height: 600,
     },
+    {
+      name: 'skyscraperSecondary',
+      id: '5e371b65b45bc586db27e9ef',
+      width: 160,
+      height: 600,
+    },
+    {
+      name: 'skyscraperTertiary',
+      id: '5e371b7cb45bc546b027e9f9',
+      width: 160,
+      height: 600,
+    },
   ]);
 module.exports = config;

--- a/tenants/bulktransporter/templates/bulk-logistics-trends.marko
+++ b/tenants/bulktransporter/templates/bulk-logistics-trends.marko
@@ -3,6 +3,8 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const skyscraperPrimary = emailX.getAdUnit({ name: "skyscraperPrimary", alias: newsletter.alias });
+$ const skyscraperSecondary = emailX.getAdUnit({ name: "skyscraperSecondary", alias: newsletter.alias });
+<!-- $ const skyscraperTertiary = emailX.getAdUnit({ name: "skyscraperTertiary", alias: newsletter.alias }); -->
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #5e1d5a; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #5e1d5a;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -100,6 +102,20 @@ $ const buttonTextStyle = {
                   <@ad-unit ...skyscraperPrimary />
                   <@params date=date email="@{email name}@"/>
                 </marko-newsletters-email-x-display>
+                <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperSecondary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display>
+                <!-- <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperTertiary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display> -->
               </td>
             </tr>
           </common-table>

--- a/tenants/refrigeratedtransporter/config/email-x.js
+++ b/tenants/refrigeratedtransporter/config/email-x.js
@@ -15,5 +15,17 @@ config
       width: 160,
       height: 600,
     },
+    {
+      name: 'skyscraperSecondary',
+      id: '5e371ba446423da7af512fc5',
+      width: 160,
+      height: 600,
+    },
+    {
+      name: 'skyscraperTertiary',
+      id: '5e371bbe46423dfd1a512fcf',
+      width: 160,
+      height: 600,
+    },
   ]);
 module.exports = config;

--- a/tenants/refrigeratedtransporter/templates/business-picture.marko
+++ b/tenants/refrigeratedtransporter/templates/business-picture.marko
@@ -3,6 +3,8 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const skyscraperPrimary = emailX.getAdUnit({ name: "skyscraperPrimary", alias: newsletter.alias });
+$ const skyscraperSecondary = emailX.getAdUnit({ name: "skyscraperSecondary", alias: newsletter.alias });
+<!-- $ const skyscraperTertiary = emailX.getAdUnit({ name: "skyscraperTertiary", alias: newsletter.alias }); -->
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #009BDE; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #009BDE;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -142,6 +144,20 @@ $ const buttonTextStyle = {
                   <@ad-unit ...skyscraperPrimary />
                   <@params date=date email="@{email name}@"/>
                 </marko-newsletters-email-x-display>
+                <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperSecondary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display>
+                <!-- <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperTertiary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display> -->
               </td>
             </tr>
           </common-table>

--- a/tenants/trailerbodybuilders/config/email-x.js
+++ b/tenants/trailerbodybuilders/config/email-x.js
@@ -15,6 +15,18 @@ config
       width: 160,
       height: 600,
     },
+    {
+      name: 'skyscraperSecondary',
+      id: '5e36f82946423d2662512f8d',
+      width: 160,
+      height: 600,
+    },
+    {
+      name: 'skyscraperTertiary',
+      id: '5e36f84446423d3c30512f97',
+      width: 160,
+      height: 600,
+    },
   ]);
 
 module.exports = config;

--- a/tenants/trailerbodybuilders/templates/market-watch.marko
+++ b/tenants/trailerbodybuilders/templates/market-watch.marko
@@ -3,6 +3,8 @@ import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const skyscraperPrimary = emailX.getAdUnit({ name: "skyscraperPrimary", alias: newsletter.alias });
+$ const skyscraperSecondary = emailX.getAdUnit({ name: "skyscraperSecondary", alias: newsletter.alias });
+<!-- $ const skyscraperTertiary = emailX.getAdUnit({ name: "skyscraperTertiary", alias: newsletter.alias }); -->
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #003366; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #003366;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -114,6 +116,20 @@ $ const buttonTextStyle = {
                   <@ad-unit ...skyscraperPrimary />
                   <@params date=date email="@{email name}@"/>
                 </marko-newsletters-email-x-display>
+                <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperSecondary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display>
+                <!-- <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
+                  Advertisement
+                </h3>
+                <marko-newsletters-email-x-display decoded-params=["email"]>
+                  <@ad-unit ...skyscraperTertiary />
+                  <@params date=date email="@{email name}@"/>
+                </marko-newsletters-email-x-display> -->
               </td>
             </tr>
           </common-table>


### PR DESCRIPTION
Added 2nd and 3rd “Skyscraper” ad units to TBB Market Watch, BT Bulk Logistics and RT Business Picture per CS-4160

Third one goes live in March I suppose.  Commented it out for now.

<img width="530" alt="Screen Shot 2020-02-02 at 10 25 48 AM" src="https://user-images.githubusercontent.com/12496550/73613515-28dd9580-45bc-11ea-9216-119e9930a243.png">

<img width="480" alt="Screen Shot 2020-02-02 at 10 28 55 AM" src="https://user-images.githubusercontent.com/12496550/73613519-2b3fef80-45bc-11ea-82ca-b3ba376ad57b.png">
