### PR TITLE
New block layout - ‘180 alt’

### DIFF
--- a/packages/common/components/style-a/blocks/180-alt-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/180-alt-section-wrapper.marko
@@ -1,0 +1,92 @@
+import isLast from "@endeavor-business-media/common/utils/is-last";
+import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  newsletter,
+  date,
+  sectionId,
+  title,
+  limit,
+  skip,
+  buttonStyle,
+  buttonTextStyle,
+  teaserStyle
+} = input;
+$ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
+$ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
+$ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "font-weight": "bold",
+  "color": "#00b398",
+  "font-size": "19.5px",
+  "line-height": "20px",
+  "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+});
+
+<common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+  <tr>
+    <td>
+      <!-- Section Query Wrapper -->
+      <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+        date: date.valueOf(),
+        newsletterId: newsletter.id,
+        sectionId: sectionId,
+        limit: limit,
+        skip: skip,
+        queryFragment: contentList,
+      }>
+        <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
+          <if(title)>
+            <tr>
+              <td>
+                <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>
+                      <h3 style=`${titleStyle}`>${title}</h3>
+                    </td>
+                  </tr>
+                </common-table>
+              </td>
+            </tr>
+          </if>
+          <tr>
+            <td valign="top">
+              <for|node, index| of=nodes>
+                <if(node.type === 'promotion')>
+                  <common-style-a-product-spotlight-180-block
+                    node=node
+                    content-link-style=contentLinkStyle
+                    button-style=buttonStyle
+                    button-text-style=buttonTextStyle
+                    teaser-style=teaserStyle
+                    image-alignment='right'
+                  />
+                </if>
+                <else>
+                  <common-style-a-product-spotlight-180-block
+                    node=node
+                    content-link-style=contentLinkStyle
+                    button-style=buttonStyle
+                    button-text-style=buttonTextStyle
+                    teaser-style=teaserStyle
+                    show-title=true
+                  />
+                </else>
+                <if(!isLast(nodes, index))>
+                  <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                    <tr>
+                      <td valign="top">
+                        <hr style="margin:0;">
+                      </td>
+                    </tr>
+                  </common-table>
+                </if>
+            </for>
+            </td>
+          </tr>
+        </common-table>
+      </marko-web-query>
+    </td>
+  </tr>
+</common-table>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -195,6 +195,41 @@
     "@main-table-style": "string",
     "@content-link-style": "object"
   },
+  "<common-style-a-180-alt-section-wrapper-block>": {
+    "template": "./180-alt-section-wrapper.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@image-alignment": {
+      "type": "string",
+      "default-value": "left"
+    },
+    "@title": "string",
+    "@title-table-style": "string",
+    "@title-style": "string",
+    "@teaser-style": "object",
+    "@button-style": "string",
+    "@button-text-style": "object",
+    "@main-table-style": "string",
+    "@content-link-style": "object"
+  },
   "<common-style-a-product-spotlight-180-section-wrapper-block>": {
     "template": "./product-spotlight-180-section-wrapper.marko",
     "@date": {

--- a/packages/common/components/style-a/blocks/product-spotlight-180.marko
+++ b/packages/common/components/style-a/blocks/product-spotlight-180.marko
@@ -55,7 +55,7 @@ $ const teaserField = node.type === 'promotion' ? 'body' : 'teaser';
     </tr>
     <tr>
       <td style=`padding: 0; padding-${imageAlignment}: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-        <common-table width=220 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align=imageAlignment class=imageAlignment padding=0 spacing=0>
+        <common-table style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align=imageAlignment class=imageAlignment padding=0 spacing=0>
           <tr>
             <td>
               <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">

--- a/tenants/fleetowner/templates/equipment-weekly.marko
+++ b/tenants/fleetowner/templates/equipment-weekly.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74448
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/fleet-owner-newsline.marko
+++ b/tenants/fleetowner/templates/fleet-owner-newsline.marko
@@ -97,25 +97,9 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=73113
       date=date
-      limit=2
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=73113
-      date=date
-      skip=2
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle

--- a/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
+++ b/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
@@ -72,7 +72,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74454
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/info-tech.marko
+++ b/tenants/fleetowner/templates/info-tech.marko
@@ -96,7 +96,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74488
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74557
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74558
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/regulation-resource-center.marko
+++ b/tenants/fleetowner/templates/regulation-resource-center.marko
@@ -82,7 +82,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74559
       date=date
       newsletter=newsletter

--- a/tenants/fleetowner/templates/top-5.marko
+++ b/tenants/fleetowner/templates/top-5.marko
@@ -55,7 +55,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74530
       date=date
       newsletter=newsletter
@@ -69,7 +69,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=74531
       title="Featured Gallery"
       date=date

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -72,7 +72,7 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <common-style-a-180-alt-section-wrapper-block
       section-id=73110
       date=date
       newsletter=newsletter


### PR DESCRIPTION
Similar to the 180 product spotlight, only images for Promotions are on the right.  Per Richard White via https://southcomm.atlassian.net/browse/CS-4149

![Screen Shot 2020-02-03 at 2 17 43 PM](https://user-images.githubusercontent.com/12496550/73687915-9955e680-4690-11ea-981f-8d2a7f2e2ade.png)

![Screen Shot 2020-02-03 at 2 13 10 PM](https://user-images.githubusercontent.com/12496550/73687921-9bb84080-4690-11ea-8af9-670389ba2954.png)
