### PR TITLE
Sponsored-By text update

### DIFF
--- a/packages/common/utils/get-sponsored-by-text.js
+++ b/packages/common/utils/get-sponsored-by-text.js
@@ -2,8 +2,8 @@ const { get } = require('@base-cms/object-path');
 
 module.exports = (node, fallbackValue = '') => {
   const { labels = [] } = node;
-  const sponsored = labels.includes('Sponsored');
+  const sponsored = labels.includes('Sponsored') || labels.includes('Sponsored By');
   if (!sponsored) return fallbackValue;
   const companyName = get(node, 'company.name');
-  return companyName ? `Sponsored by ${companyName}` : 'Sponsored';
+  return companyName ? `${labels[0]} ${companyName}` : labels[0];
 };

--- a/tenants/machinedesign/templates/special-edition.marko
+++ b/tenants/machinedesign/templates/special-edition.marko
@@ -43,7 +43,7 @@ $ const isFull = false;
 
     <common-style-a-section-spacer-block />
 
-    <!-- Generic Single Column A -->
+    <!-- #1 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80794
       date=date
@@ -56,7 +56,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column B -->
+    <!-- #2 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80796
       date=date
@@ -67,7 +67,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Features 1 Column -->
+    <!-- #3 Features - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80784
       title="Features"
@@ -81,7 +81,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Features 2 Column -->
+    <!-- #4 Features - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80785
       title="Features"
@@ -95,7 +95,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Double Column A-->
+    <!-- #5 Generic - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80795
       date=date
@@ -106,7 +106,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column C -->
+    <!-- #6 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80798
       date=date
@@ -117,7 +117,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- News 1 Column -->
+    <!-- #7 News - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80786
       title="News"
@@ -131,7 +131,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- News 2 Column -->
+    <!-- #8 News - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80787
       title="News"
@@ -145,7 +145,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Double Column B-->
+    <!-- #9 Generic - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80797
       date=date
@@ -156,7 +156,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column D -->
+    <!-- #10 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80801
       date=date
@@ -167,7 +167,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Products 1 Column -->
+    <!-- #11 Products - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80788
       title="Products"
@@ -181,7 +181,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Products 2 Column -->
+    <!-- #12 Products - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80789
       title="Products"
@@ -195,7 +195,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Double Column C-->
+    <!-- #13 Generic - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80799
       date=date
@@ -206,7 +206,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column E -->
+    <!-- #14 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80802
       date=date
@@ -217,7 +217,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Videos 1 Column -->
+    <!-- #15 Videos - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80790
       title="Videos"
@@ -231,7 +231,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Videos 2 Column -->
+    <!-- #16 Videos - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80791
       title="Videos"
@@ -245,7 +245,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Double Column D-->
+    <!-- #17 Generic - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80801
       date=date
@@ -256,7 +256,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column F -->
+    <!-- #18 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80803
       date=date
@@ -267,7 +267,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Whitepapers 1 Column -->
+    <!-- #19 Whitepapers 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80792
       title="Whitepapers"
@@ -281,7 +281,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Whitepapers 2 Column -->
+    <!-- #20 Whitepapers - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80793
       title="Whitepapers"
@@ -295,7 +295,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Double Column E-->
+    <!-- #21 Generic - 2 Column -->
     <common-style-a-card-section-wrapper-block
       section-id=80804
       date=date
@@ -306,7 +306,7 @@ $ const isFull = false;
       button-text-style=buttonTextStyle
     />
 
-    <!-- Generic Single Column G -->
+    <!-- #22 Generic - 1 Column -->
     <common-style-a-special-edition-full-wrapper-block
       section-id=80805
       date=date


### PR DESCRIPTION
Sets label name as the little text above promotions, so they can put whatever they want “Sponsored” vs “Sponsored By”, or “Advertise” as the fallback, etc.

Also renamed the sections in the Special Edition template, updated the comments to correspond with what's in Base