### PR TITLE
Remove “Advertisement” as the default Label for Promotions

### DIFF
--- a/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
@@ -45,7 +45,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, 'Advertisement')}
+              $!{getSponsoredByText(node, '&nbsp;')}
             </div>
           </td>
         </tr>


### PR DESCRIPTION
Promotions are supposed to appear as though they’re normal content, so if they manually add a label it will appear (Sponsored/Sponsored By) but otherwise it won’t add the “Advertisement” label by default.

Manual "Sponsored" label added to Promotion:
![image](https://user-images.githubusercontent.com/12496550/74239593-c3fdfb80-4c9d-11ea-85fc-266ddd918bf8.png)

