### PR TITLE
Mobile leaderboard css targeting

### DIFF
--- a/packages/common/components/style-a/default-style.marko
+++ b/packages/common/components/style-a/default-style.marko
@@ -43,7 +43,7 @@
       width: 340px !important;
     }
     .scaleAd,
-    .email-x-grid-innovations-leaderboardPrimary img {
+    .scaleAd img {
       width: 320px !important;
       height: auto !important;
     }

--- a/tenants/asumag/templates/facilities-focus.marko
+++ b/tenants/asumag/templates/facilities-focus.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/asumag/templates/first-monday-product-news.marko
+++ b/tenants/asumag/templates/first-monday-product-news.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display dclass="scaleAd" ecoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/asumag/templates/first-monday-product-news.marko
+++ b/tenants/asumag/templates/first-monday-product-news.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display dclass="scaleAd" ecoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/asumag/templates/green-school-university.marko
+++ b/tenants/asumag/templates/green-school-university.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/asumag/templates/schoolhouse-beat.marko
+++ b/tenants/asumag/templates/schoolhouse-beat.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/code-watch.marko
+++ b/tenants/ecmweb/templates/code-watch.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/electrical-zone.marko
+++ b/tenants/ecmweb/templates/electrical-zone.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/etrain.marko
+++ b/tenants/ecmweb/templates/etrain.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/illumination-insider.marko
+++ b/tenants/ecmweb/templates/illumination-insider.marko
@@ -60,7 +60,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/lightfair-show-coverage.marko
+++ b/tenants/ecmweb/templates/lightfair-show-coverage.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/mro-insider.marko
+++ b/tenants/ecmweb/templates/mro-insider.marko
@@ -60,7 +60,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/neca-show-coverage.marko
+++ b/tenants/ecmweb/templates/neca-show-coverage.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/pq-news-beat.marko
+++ b/tenants/ecmweb/templates/pq-news-beat.marko
@@ -60,7 +60,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/product-news-wire.marko
+++ b/tenants/ecmweb/templates/product-news-wire.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/ecmweb/templates/safety-matters.marko
+++ b/tenants/ecmweb/templates/safety-matters.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/equipment-weekly.marko
+++ b/tenants/fleetowner/templates/equipment-weekly.marko
@@ -48,7 +48,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/fleet-owner-newsline.marko
+++ b/tenants/fleetowner/templates/fleet-owner-newsline.marko
@@ -73,7 +73,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
+++ b/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
@@ -47,7 +47,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/info-tech.marko
+++ b/tenants/fleetowner/templates/info-tech.marko
@@ -72,7 +72,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/regulation-resource-center.marko
+++ b/tenants/fleetowner/templates/regulation-resource-center.marko
@@ -72,7 +72,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/fleetowner/templates/top-5.marko
+++ b/tenants/fleetowner/templates/top-5.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/rermag/templates/rer-product-wire.marko
+++ b/tenants/rermag/templates/rer-product-wire.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/rermag/templates/rer-reports.marko
+++ b/tenants/rermag/templates/rer-reports.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/careers.marko
+++ b/tenants/tdworld/templates/careers.marko
@@ -61,7 +61,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -77,7 +77,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/grid-innovations.marko
+++ b/tenants/tdworld/templates/grid-innovations.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/smart-utility.marko
+++ b/tenants/tdworld/templates/smart-utility.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/test-monitor-control.marko
+++ b/tenants/tdworld/templates/test-monitor-control.marko
@@ -46,7 +46,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/tdworld/templates/vegetation-management-insights.marko
+++ b/tenants/tdworld/templates/vegetation-management-insights.marko
@@ -46,7 +46,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/trailerbodybuilders/templates/buyers-express.marko
+++ b/tenants/trailerbodybuilders/templates/buyers-express.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/trailerbodybuilders/templates/the-latest-issue.marko
+++ b/tenants/trailerbodybuilders/templates/the-latest-issue.marko
@@ -45,7 +45,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -47,7 +47,7 @@ $ const buttonTextStyle = {
           <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
             Advertisement
           </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
+          <marko-newsletters-email-x-display class="scaleAd" decoded-params=["email"]>
             <@ad-unit ...leaderboardPrimary />
             <@params date=date email="@{email name}@"/>
           </marko-newsletters-email-x-display>


### PR DESCRIPTION
Leaderboard wasn't scaling down on mobile in Gmail.  Stupid Gmail.

All better:
<img width="503" alt="Screen Shot 2020-02-18 at 10 00 16 AM" src="https://user-images.githubusercontent.com/12496550/74754126-c977ba80-5236-11ea-8d3a-9fc458b7e521.png">
