### PR TITLE
Standardizing Manufacturing Newsletters

### DIFF
--- a/packages/common/components/style-a/blocks/simple-card-full.marko
+++ b/packages/common/components/style-a/blocks/simple-card-full.marko
@@ -38,74 +38,107 @@ $ const buttonTextStyle = defaultValue(input.buttonTextStyle, {
 $ const innerPadding = 20;
 $ const innerTableWidth = tableWidth - (innerPadding * 2);
 
-<common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main" padding=0 spacing=0>
-  <tr>
-    <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-      <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
-        <tr>
-          <td>
-            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, '&nbsp;')}
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-              <marko-newsletter-imgix
-                src=image.src
-                alt=image.alt
-                options={ w: imgWidth }
-                class="main"
-                attrs={ border: 0, width: imgWidth }
-              >
-                <@link href=node.siteContext.url target="_blank" />
-              </marko-newsletter-imgix>
-            </marko-core-obj-value>
-          </td>
-        </tr>
-      </common-table>
-    </td>
-  </tr>
-</common-table>
-
-<common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="main right" padding=0 spacing=0>
-  <tr>
-    <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-      <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-        <tr>
-          <td>
-            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              &nbsp;
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-            </marko-core-obj-text>
-            <div height="10">&nbsp;</div>
-            <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
-          </td>
-        </tr>
-      </common-table>
-    </td>
-  </tr>
-</common-table>
-
-<common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="center" class=`${alignment}` padding=0 spacing=0>
-  <tr>
-    <td style=`padding: 0; padding-${alignment}: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-      <common-table align="center" padding=0 spacing=0>
-        <tr>
-          <td style=`${buttonStyle}`>
-            <marko-core-text value=getButtonText(node.type)>
-              <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-            </marko-core-text>
+<if(node.primaryImage)>
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: 0px;`>
+        <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
+          <tr>
+            <td>
+              <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
+                $!{getSponsoredByText(node, '&nbsp;')}
+              </div>
             </td>
           </tr>
-      </common-table>
-    </td>
-  </tr>
-</common-table>
+          <tr>
+            <td>
+              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                <marko-newsletter-imgix
+                  src=image.src
+                  alt=image.alt
+                  options={ w: imgWidth }
+                  class="main"
+                  attrs={ border: 0, width: imgWidth }
+                >
+                  <@link href=node.siteContext.url target="_blank" />
+                </marko-newsletter-imgix>
+              </marko-core-obj-value>
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="main right" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: 0; padding-right: ${innerPadding}px;`>
+        <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding-bottom": "5px" } } >
+                <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+              </marko-core-obj-text>
+              <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+
+  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="center" class=`${alignment}` padding=0 spacing=0>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td align="center">
+        <common-table align="center" padding=0 spacing=0>
+
+          <tr>
+            <td style=`${buttonStyle}`>
+              <marko-core-text value=getButtonText(node.type)>
+                <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+              </marko-core-text>
+              </td>
+            </tr>
+        </common-table>
+      </td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+  </common-table>
+</if>
+<else>
+  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td style=`padding: ${innerPadding}px;`>
+        <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding-bottom": "5px" } } >
+          <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+        </marko-core-obj-text>
+
+        <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+
+        <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
+          <tr>
+            <td style=`${buttonStyle}`>
+              <marko-core-text value=getButtonText(node.type)>
+                <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+              </marko-core-text>
+              </td>
+            </tr>
+        </common-table>
+      </td>
+    </tr>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+  </common-table>
+</else>

--- a/packages/common/components/style-a/blocks/special-edition-featured-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-featured-promotion.marko
@@ -41,9 +41,6 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
     <td style=`padding: 0 ${innerPadding}px;`>
       <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
         <tr>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
               $!{getSponsoredByText(node, '&nbsp;')}
@@ -76,7 +73,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
       <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
         <tr>
           <td>
-            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding": "10px 0" } } >
+            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding-bottom": "10px" } } >
               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
             </marko-core-obj-text>
             <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />

--- a/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
@@ -38,79 +38,97 @@ $ const buttonTextStyle = defaultValue(input.buttonTextStyle, {
 $ const innerPadding = 20;
 $ const innerTableWidth = tableWidth - (innerPadding * 2);
 
-<common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main" padding=0 spacing=0>
-  <tr>
-    <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-      <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
-        <tr>
-          <td>
-            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, '&nbsp;')}
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-              <marko-newsletter-imgix
-                src=image.src
-                alt=image.alt
-                options={ w: imgWidth }
-                class="main"
-                attrs={ border: 0, width: imgWidth }
-              >
-                <@link href=node.siteContext.url target="_blank" />
-              </marko-newsletter-imgix>
-            </marko-core-obj-value>
-          </td>
-        </tr>
-      </common-table>
-    </td>
-  </tr>
-</common-table>
-
-<common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="main right" padding=0 spacing=0>
-  <tr>
-    <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-      <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-        <tr>
-          <td>
-            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              &nbsp;
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-            </marko-core-obj-text>
-            <div height="10">&nbsp;</div>
-            <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
-          </td>
-        </tr>
-      </common-table>
-    </td>
-  </tr>
-</common-table>
-
-<if(node.linkText)>
-  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="center" class=`${alignment}` padding=0 spacing=0>
+<if(node.primaryImage)>
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main" padding=0 spacing=0>
     <tr>
-      <td align="center">
-        <common-table align="center" padding=0 spacing=0>
+      <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+        <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
           <tr>
-            <td style=`${buttonStyle}`>
-              <marko-core-text value=node.linkText>
-                <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-              </marko-core-text>
+            <td>
+              <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
+                $!{getSponsoredByText(node, '&nbsp;')}
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                <marko-newsletter-imgix
+                  src=image.src
+                  alt=image.alt
+                  options={ w: imgWidth }
+                  class="main"
+                  attrs={ border: 0, width: imgWidth }
+                >
+                  <@link href=node.siteContext.url target="_blank" />
+                </marko-newsletter-imgix>
+              </marko-core-obj-value>
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+
+  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="main right" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
+        <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding-bottom": "10px" } } >
+                <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+              </marko-core-obj-text>
+
+              <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+
+              <if(node.linkText)>
+                <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
+                  <tr>
+                    <td style=`${buttonStyle}`>
+                      <marko-core-text value=node.linkText>
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                      </marko-core-text>
+                    </td>
+                  </tr>
+                </common-table>
+              </if>
+
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+</if>
+<else>
+  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: ${innerPadding}px;`>
+        <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left", "padding-bottom": "10px" } } >
+          <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+        </marko-core-obj-text>
+
+        <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+
+        <if(node.linkText)>
+          <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
+            <tr>
+              <td style=`${buttonStyle}`>
+                <marko-core-text value=node.linkText>
+                  <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
+                </marko-core-text>
               </td>
             </tr>
-        </common-table>
+          </common-table>
+        </if>
       </td>
     </tr>
     <tr>
       <td>&nbsp;</td>
     </tr>
   </common-table>
-</if>
+</else>

--- a/tenants/americanmachinist/templates/imts-preview.marko
+++ b/tenants/americanmachinist/templates/imts-preview.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #0b78b1; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #0b78b1;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,24 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74540
-      title="Gallery"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74541
-      title="Articles"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81084
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74540
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -67,17 +72,78 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81086
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-    <common-style-a-title-teaser-block
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
       section-id=74542
-      title="Plan Ahead"
+      title="In The Spotlight"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81088
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81093
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81089
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81095
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81092
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/americanmachinist/templates/weekly-update.marko
+++ b/tenants/americanmachinist/templates/weekly-update.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #0b78b1; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #0b78b1;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,60 +39,111 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74526
-      title="Gallery"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74527
-      title="This week's news"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74528
-      title="New Products"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-title-teaser-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74529
-      title="Events"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81083
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74527
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81085
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74526
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81087
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74528
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81090
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81094
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81091
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/ehstoday/components/blocks/header.marko
+++ b/tenants/ehstoday/components/blocks/header.marko
@@ -18,7 +18,7 @@ $ const {
       <h1 style="color: #fff; font-size: 26px; line-height: 28px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;">
         ${newsletter.name}
       </h1>
-      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;">
+      <p style="color: #ffffff; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 15px 0 15px; font-weight: 300; line-height: 15px;">
         $!{newsletter.description}
       </p>
     </td>

--- a/tenants/ehstoday/templates/construction-safety.marko
+++ b/tenants/ehstoday/templates/construction-safety.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #005844; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #005844;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -31,8 +31,6 @@ $ const teaserStyle = {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
 
-$ const imgWidth = 160;
-
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -46,41 +44,114 @@ $ const imgWidth = 160;
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-section-spacer-block />
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74506
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74506
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80770
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80965
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-        <td width="200" align="center" valign="top">
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80949
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=80970
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-right-rail-block
-            section-id=80770
-            date=date
-            newsletter=newsletter
-            main-table-style=mainTableStyle
-          />
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80953
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
-      </tr>
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80974
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-    </common-table>
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80957
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80978
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80961
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/management.marko
+++ b/tenants/ehstoday/templates/management.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #005844; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #005844;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -44,41 +44,114 @@ $ const teaserStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-section-spacer-block />
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74533
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74533
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80771
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80966
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-        <td width="200" align="center" valign="top">
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80950
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=80971
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-right-rail-block
-            section-id=80771
-            date=date
-            newsletter=newsletter
-            main-table-style=mainTableStyle
-          />
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80954
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
-      </tr>
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80975
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-    </common-table>
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80958
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80979
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80962
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/safety-tech-analytics-news.marko
+++ b/tenants/ehstoday/templates/safety-tech-analytics-news.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #005844; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #005844;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -44,41 +44,114 @@ $ const teaserStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-section-spacer-block />
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74446
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74446
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80769
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80969
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-        <td width="200" align="center" valign="top">
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80952
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=80973
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-right-rail-block
-            section-id=80769
-            date=date
-            newsletter=newsletter
-            main-table-style=mainTableStyle
-          />
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80956
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
-      </tr>
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80977
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-    </common-table>
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80960
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80981
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80964
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/ehstoday/templates/weekly-update.marko
+++ b/tenants/ehstoday/templates/weekly-update.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #005844; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #005844;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -44,44 +44,116 @@ $ const teaserStyle = {
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
-
-          <common-style-a-section-spacer-block />
-
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74416
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
-
-        </td>
-
-        <td width="200" align="center" valign="top">
-
-          <common-style-a-section-spacer-block />
-
-          <common-style-a-right-rail-block
-            section-id=80768
-            date=date
-            newsletter=newsletter
-            main-table-style=mainTableStyle
-          />
-
-        </td>
-      </tr>
-
-    </common-table>
-
     <common-style-a-section-spacer-block />
 
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74416
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80768
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80967
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80951
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=80972
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80955
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80976
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80959
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80980
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80963
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <common-style-a-section-spacer-block />
     <common-style-a-opt-out-block />
 
   </@body>

--- a/tenants/forgingmagazine/templates/e-newsletter.marko
+++ b/tenants/forgingmagazine/templates/e-newsletter.marko
@@ -1,7 +1,6 @@
 import emailX from "../config/email-x";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e63c2e; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e63c2e;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,75 +38,111 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74520
-      title="Gallery"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74521
-      title="This week's news"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74522
-      title="Featured this week"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74523
-      title="New Products"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-title-teaser-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74524
-      title="Events"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81096
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74522
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81097
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74520
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81098
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74523
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81099
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74521
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81100
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/foundrymag/templates/metalcasting-weekly.marko
+++ b/tenants/foundrymag/templates/metalcasting-weekly.marko
@@ -1,7 +1,6 @@
 import emailX from "../config/email-x";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #732533; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #732533;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,90 +38,111 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74514
-      title="Gallery"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74515
-      title="This week's metalcasting news"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74516
-      title="ASK the Expert"
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74517
-      title="Featured this week"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74518
-      title="New Products"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-title-teaser-block
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74519
-      title="Events"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74517
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81101
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74514
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81102
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74518
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81103
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74515
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81104
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/continuous-improvements.marko
+++ b/tenants/industryweek/templates/continuous-improvements.marko
@@ -3,7 +3,6 @@ import contentList from "@endeavor-business-media/common/graphql/fragments/conte
 import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -49,177 +48,29 @@ $ const teaserStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74417,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, 'Advertisement')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 180 }
-                                      class="main"
-                                      attrs={ border: 0, width: 180 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-featured-section-wrapper-block
-      section-id=74418
-      title="Top Story"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74419
-      title="Recent Reads"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74420
-      title="Benchmarking Brief"
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74421
-      title="Lessons Learned"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74422
-      title="Best Practices Site of Interest"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74417
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -230,26 +81,18 @@ $ const teaserStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74423
-      title="On the Bookshelf"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74424
-      title="IW Archives"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74419
+      title="In The Spotlight"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -258,6 +101,58 @@ $ const teaserStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80988
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74418
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74421
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81020
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74423
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredContentLinkStyle = {
@@ -65,20 +65,18 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74411
       date=date
-      limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
+    <!-- #02 - Leaderboard - 1 Column -->
     <common-style-a-leaderboard-block
       section-id=80872
       date=date
@@ -86,10 +84,11 @@ $ const buttonTextStyle = {
       main-table-style=mainTableStyle
     />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74411
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81029
+      title="Editor's Note"
       date=date
-      skip=1
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
@@ -97,6 +96,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81030
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81031
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81032
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81033
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81034
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81035
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81036
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/daily-headlines-morning-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-morning-edition.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const featuredTitleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const featuredMainTableStyle = "border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; background-color: #333333; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
 $ const featuredContentLinkStyle = {
@@ -65,24 +65,30 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-featured-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74410
       date=date
-      limit=1
       newsletter=newsletter
-      main-table-style=featuredMainTableStyle
-      content-link-style=featuredContentLinkStyle
-      teaser-style=featuredTeaserStyle
-      button-style=featuredButtonStyle
-      button-text-style=featuredButtonTextStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74410
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80982
       date=date
-      skip=1
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80983
+      title="Editor's Note"
+      date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
@@ -90,6 +96,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80985
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81005
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80987
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81012
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80994
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81019
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80998
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/leadership-insights.marko
+++ b/tenants/industryweek/templates/leadership-insights.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,67 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74455
-      title="Strategic Management"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74456
-      title="News & Research"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74457
-      title="Commentary"
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74458
-      title="ICYMI"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74459
-      title="Gallery"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74458
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -108,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74456
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81007
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80990
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81014
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74455
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81022
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81000
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/manufacturing-technology.marko
+++ b/tenants/industryweek/templates/manufacturing-technology.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,25 +39,95 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74464
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74466
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74465
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74463
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81008
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80991
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81015
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74462
       date=date
-      allow-full-promotion=true
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-featured-section-wrapper-block
-      section-id=74463
-      title="MT Spotlight"
-      limit=1
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81023
+      title="Editor's Choice"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -68,49 +138,12 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74464
-      title="MT Features"
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81001
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74465
-      title="MT News"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-full-third-two-thirds-section-wrapper-block
-      section-id=74466
-      title="MT Gallery"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/quick-manufacturing-news.marko
+++ b/tenants/industryweek/templates/quick-manufacturing-news.marko
@@ -1,11 +1,8 @@
 import emailX from "../config/email-x";
-import isLast from "@endeavor-business-media/common/utils/is-last";
-import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #000; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #000;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -34,12 +31,6 @@ $ const teaserStyle = {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
 
-$ const getReadMoreText = (node) => {
-  const { type, typeTitle } = node;
-  const viewType = ["video", "photo-gallery", "whitepaper"];
-  return viewType.includes(type) ? node.typeTitle : `Full ${node.typeTitle}`;
-};
-
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -57,662 +48,138 @@ $ const getReadMoreText = (node) => {
 
     <common-style-a-section-spacer-block />
 
-    <!-- <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td style="font-family: Arial, sans-serif; font-size: 13px; line-height: 20px; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
-          <h3 style="margin:0;font-weight:bold;height:27px;margin:1px 0 5px 0px; font-family:Helvetica, Arial, sans-serif; font-size:11px; color:#999;text-align:left;">
-            Advertisement
-          </h3>
-          <marko-newsletters-email-x-display decoded-params=["email"]>
-            <@ad-unit ...leaderboardPrimary />
-            <@params date=date email="@{email name}@"/>
-          </marko-newsletters-email-x-display>
-        </td>
-      </tr>
-    </common-table>
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80744
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-    <common-style-a-section-spacer-block /> -->
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74402
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74402,
-            limit: 1,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, 'Advertisement')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 180 }
-                                      class="main"
-                                      attrs={ border: 0, width: 180 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                    <if(!isLast(nodes, index))>
-                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                        <tr>
-                          <td valign="top">
-                            <hr style="margin:0;">
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74403
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74405
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81011
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74404
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81018
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80997
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81026
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81004
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #11 - Product Spotlight - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81027
+      title="Product Spotlight, Courtesy of NewEquipment.com"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #12 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81028
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
     <common-style-a-section-spacer-block />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74403,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-                <tr>
-                  <td>
-                    <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
-                      <tr>
-                        <td>
-                          <h3 style=`${titleStyle}`>Industry Voices</h3>
-                        </td>
-                      </tr>
-                    </common-table>
-                  </td>
-                </tr>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, '&nbsp;')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 260 }
-                                      class="main"
-                                      attrs={ border: 0, width: 260 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                                  </marko-core-obj-text>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                    <if(!isLast(nodes, index))>
-                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                        <tr>
-                          <td valign="top">
-                            <hr style="margin:0;">
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
-
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74404,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-                <tr>
-                  <td>
-                    <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
-                      <tr>
-                        <td>
-                          <h3 style=`${titleStyle}`>Today's Daily News</h3>
-                        </td>
-                      </tr>
-                    </common-table>
-                  </td>
-                </tr>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, '&nbsp;')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 260 }
-                                      class="main"
-                                      attrs={ border: 0, width: 260 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="righ" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                                  </marko-core-obj-text>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                    <if(!isLast(nodes, index))>
-                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                        <tr>
-                          <td valign="top">
-                            <hr style="margin:0;">
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
-
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74405,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-                <tr>
-                  <td>
-                    <common-table width="100%" style=titleTableStyle align="center" class="main" padding=0 spacing=0>
-                      <tr>
-                        <td>
-                          <h3 style=`${titleStyle}`>Product Spotlight, Courtesy of NewEquipment.com</h3>
-                        </td>
-                      </tr>
-                    </common-table>
-                  </td>
-                </tr>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, '&nbsp;')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 260 }
-                                      class="main"
-                                      attrs={ border: 0, width: 260 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=400 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                                  </marko-core-obj-text>
-
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                    <if(!isLast(nodes, index))>
-                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                        <tr>
-                          <td valign="top">
-                            <hr style="margin:0;">
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
-
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 80744,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, 'Advertisement')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 180 }
-                                      class="main"
-                                      attrs={ border: 0, width: 180 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.linkUrl target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                    <if(!isLast(nodes, index))>
-                      <common-table width="100%" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                        <tr>
-                          <td valign="top">
-                            <hr style="margin:0;">
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-
-    <common-style-a-section-spacer-block />
+<!-- Footer -->
 
     <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0 attrs={ style: { "background-color": "#e5e5e5" } } >
       <tr>

--- a/tenants/industryweek/templates/supply-chain-insights.marko
+++ b/tenants/industryweek/templates/supply-chain-insights.marko
@@ -1,10 +1,7 @@
 import emailX from "../config/email-x";
-import isLast from "@endeavor-business-media/common/utils/is-last";
-import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -49,143 +46,30 @@ $ const teaserStyle = {
     <tenant-header-block date=date newsletter=newsletter />
 
     <common-style-a-section-spacer-block />
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td>
-          <!-- Section Query Wrapper -->
-          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
-            date: date.valueOf(),
-            newsletterId: newsletter.id,
-            sectionId: 74412,
-            limit: 1,
-            queryFragment: contentList,
-          }>
-            <common-table width="700" style=mainTableStyle align="left" class="main" padding=0 spacing=0>
-              <tr>
-                <td valign="top">
-                  $ const tableWidth = 700;
-                  $ const innerPadding = 20;
-                  $ const innerTableWidth = tableWidth - (innerPadding * 2);
-                  <for|node, index| of=nodes>
-                    <if(node.primaryImage)>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="right" padding=0 spacing=0>
-                        <tr>
-                          <td style="padding-left: 20px;">
-                            <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-                              $!{getSponsoredByText(node, 'Advertisement')}
-                            </div>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td style=`padding: 0; padding-right: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                            <common-table width=200 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 180 }
-                                      class="main"
-                                      attrs={ border: 0, width: 180 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <common-table width=450 style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                              <tr>
-                                <td style=`padding: 0 ${innerPadding}px ${innerPadding}px ${innerPadding}px;`>
-                                  <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                                </td>
-                              </tr>
-                              <if(node.linkText)>
-                                <tr>
-                                  <td style=`padding: 0; padding-left: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </if>
-                            </common-table>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </if>
-                    <else>
-                      <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
-                        <tr>
-                          <td style=`padding: ${innerPadding}px;`>
-                            <marko-core-obj-text tag="span" obj=node field="body" html=true attrs={ style: teaserStyle } />
-                            <if(node.linkText)>
-                              <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
-                                <tr>
-                                  <td style=`padding: 0; padding-right: ${innerPadding}px; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
-                                    <common-table align="center" padding=0 spacing=0>
-                                      <tr>
-                                        <td style=`${buttonStyle}`>
-                                          <marko-core-text value=node.linkText>
-                                            <@link href=node.siteContext.url target="_blank" attrs={ style: buttonTextStyle } />
-                                          </marko-core-text>
-                                          </td>
-                                        </tr>
-                                    </common-table>
-                                  </td>
-                                </tr>
-                              </common-table>
-                            </if>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </else>
-                  </for>
-                </td>
-              </tr>
-            </common-table>
-          </marko-web-query>
-        </td>
-      </tr>
-    </common-table>
-    <!-- <common-style-a-featured-section-wrapper-block
-      section-id=74412
-      limit=1
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    /> -->
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74413
-      title="Commentary & Analysis"
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-card-section-wrapper-block
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74412
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74414
-      title="Features"
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -196,11 +80,18 @@ $ const teaserStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=74415
-      title="News"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81009
+      title="In The Spotlight"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -209,6 +100,58 @@ $ const teaserStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80992
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81016
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80996
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81024
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81002
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/industryweek/templates/weekly-hotlist.marko
+++ b/tenants/industryweek/templates/weekly-hotlist.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,10 +39,30 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74460
       date=date
-      allow-full-promotion=true
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74461
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=80984
+      title="Editor's Note"
+      date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
       title-style=titleStyle
@@ -52,10 +72,39 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80986
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
-      section-id=74461
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81006
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80989
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81013
       title="Top Stories"
       date=date
       newsletter=newsletter
@@ -67,7 +116,37 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-opt-out-block />
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80995
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81021
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80999
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <common-style-a-section-spacer-block />
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/workforce-watch.marko
+++ b/tenants/industryweek/templates/workforce-watch.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #ba1f31; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #ba1f31;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,67 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74449
-      date=date
-      newsletter=newsletter
-      allow-full-promotion=true
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-featured-section-wrapper-block
-      section-id=74450
-      title="WW Spotlight"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74451
-      title="Strategic Management"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74452
-      title="Recent Reads"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74453
-      title="Gallery"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74452
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74449
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -108,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74451
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81010
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80993
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81017
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74450
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81025
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81003
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/mhlnews/templates/newsmakers.marko
+++ b/tenants/mhlnews/templates/newsmakers.marko
@@ -2,7 +2,6 @@ import emailX from "../config/email-x";
 import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #003E51; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #003E51;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -32,8 +31,6 @@ $ const teaserStyle = {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
 
-$ const imgWidth = 160;
-
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -47,121 +44,118 @@ $ const imgWidth = 160;
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-section-spacer-block />
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74441
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74439
-            title="Spotlight"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80767
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74440
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74440
-            title="Industry News"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74444
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74442
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74441
-            title="Commentary & Analysis"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81106
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74439
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-list-section-wrapper-block
-            section-id=74442
-            title="Last Weeks Top 3 Stories"
-            limit=3
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            alignment="left"
-            table-width="480"
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-          />
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81105
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74443
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74443
-            title="Webinars"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81107
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74444
-            title="Whitepapers"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
-          </td>
-
-          <td width="200" align="center" valign="top">
-
-            <common-style-a-section-spacer-block />
-
-            <common-style-a-right-rail-block
-              section-id=80767
-              date=date
-              newsletter=newsletter
-              main-table-style=mainTableStyle
-            />
-
-          </td>
-        </tr>
-
-      </common-table>
-
-      <common-style-a-section-spacer-block />
-
-      <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block />
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -2,7 +2,6 @@ import emailX from "../config/email-x";
 import contentList from "@endeavor-business-media/common/graphql/fragments/content-list";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #003E51; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #003E51;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -32,7 +31,6 @@ $ const teaserStyle = {
   "font-family": "Arial, 'Helvetica Neue', Helvetica, sans-serif"
 };
 
-$ const imgWidth = 160;
 
 <marko-newsletter-root
   title=newsletter.name
@@ -47,88 +45,114 @@ $ const imgWidth = 160;
     />
     <tenant-header-block date=date newsletter=newsletter />
 
-    <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-      <tr>
-        <td width="500" valign="top" align="left">
+    <common-style-a-section-spacer-block />
 
-          <common-style-a-section-spacer-block />
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81108
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74435
-            title="Editor's Choice"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=80766
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74438
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-list-section-wrapper-block
-            section-id=74436
-            title="Last Weeks Top 3 Stories"
-            limit=3
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            table-width="480"
-            alignment="left"
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-          />
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81109
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74437
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74437
-            title="Webinars"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81110
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-          <common-style-a-section-spacer-block />
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74436
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-          <common-style-a-left-two-thirds-section-wrapper-block
-            section-id=74438
-            title="Whitepapers"
-            date=date
-            newsletter=newsletter
-            title-table-style=titleTableStyle
-            title-style=titleStyle
-            main-table-style=mainTableStyle
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
-          />
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81111
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-        </td>
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74435
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
 
-        <td width="200" align="center" valign="top">
-
-          <common-style-a-section-spacer-block />
-
-          <common-style-a-right-rail-block
-            section-id=80766
-            date=date
-            newsletter=newsletter
-            main-table-style=mainTableStyle
-          />
-
-        </td>
-    </tr>
-
-    </common-table>
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81112
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
     <common-style-a-section-spacer-block />
 

--- a/tenants/newequipment/templates/industry-insider.marko
+++ b/tenants/newequipment/templates/industry-insider.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,24 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=73116
-      title="Top Story"
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=73119
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
       section-id=73117
-      title="Industry News"
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=73118
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -67,10 +72,61 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81045
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=73118
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=73116
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81051
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81073
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81057
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81078
       title="Editor's Choice"
       date=date
       newsletter=newsletter
@@ -82,19 +138,12 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=73119
-      title="Hot New Products"
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81063
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/newequipment/templates/maintenance-operations.marko
+++ b/tenants/newequipment/templates/maintenance-operations.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,8 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81037
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81041
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74549
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -49,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81047
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81069
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81053
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81074
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81059
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81079
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81065
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/newequipment/templates/material-handling-robotics.marko
+++ b/tenants/newequipment/templates/material-handling-robotics.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,8 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81038
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81042
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74551
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -49,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81048
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81070
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81054
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81075
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81060
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81080
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81066
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/newequipment/templates/smart-manufacturing-iot.marko
+++ b/tenants/newequipment/templates/smart-manufacturing-iot.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,8 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81039
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81043
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74554
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -49,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81049
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81071
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81055
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81076
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81061
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81081
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81067
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/newequipment/templates/tools-ppe.marko
+++ b/tenants/newequipment/templates/tools-ppe.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,8 +39,29 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-product-spotlight-180-section-wrapper-block
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81040
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81044
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74556
+      title="Editor's Note"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -49,6 +70,80 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81050
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=81072
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81056
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81077
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81062
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=81082
+      title="Editor's Choice"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81068
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
     />
 
     <common-style-a-section-spacer-block />

--- a/tenants/newequipment/templates/week-in-review.marko
+++ b/tenants/newequipment/templates/week-in-review.marko
@@ -1,7 +1,7 @@
 import emailX from "../config/email-x";
+import getSponsoredByText from "@endeavor-business-media/common/utils/get-sponsored-by-text";
 
 $ const { newsletter, date } = data;
-$ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alias: newsletter.alias });
 $ const titleTableStyle = "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #e65525; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #e65525;";
 $ const titleStyle = "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;";
 $ const mainTableStyle ="border-collapse:collapse; font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; border-bottom: 2px solid #d7d7d7; border-top: 2px solid #d7d7d7; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
@@ -39,53 +39,94 @@ $ const buttonTextStyle = {
 
     <common-style-a-section-spacer-block />
 
-    <common-style-a-card-section-wrapper-block
-      section-id=74500
-      title="Top Story"
+    <!-- #01 - Generic - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74504
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74501
-      title="Leading Story"
+    <!-- #02 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=74505
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74502
-      title="key Suppliers"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
+    <!-- #03 - Editor's Note - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74503
+      title="Editor's Note"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #04 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81046
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #05 - In The Spotlight - 1 Column - Big Image -->
+    <common-style-a-special-edition-featured-wrapper-block
+      section-id=74500
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #06 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81052
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #07 - Top Stories - 1 Column  -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74502
+      title="Top Stories"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <!-- #08 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81058
+      date=date
+      newsletter=newsletter
+      main-table-style=mainTableStyle
+    />
+
+    <!-- #09 - Editor’s Choice - 1 Column -->
+    <common-style-a-special-edition-full-wrapper-block
+      section-id=74501
       title="Editor's Choice"
       date=date
       newsletter=newsletter
@@ -97,19 +138,12 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-section-spacer-block />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=74504
-      title="Catalogs"
+    <!-- #10 - Leaderboard - 1 Column -->
+    <common-style-a-leaderboard-block
+      section-id=81064
       date=date
       newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
       main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
     />
 
     <common-style-a-section-spacer-block />


### PR DESCRIPTION
Based on: https://docs.google.com/document/d/1xRGqSo8REjg5e_sjjkQyNOi4e-W8T_b-l-h6Hc38Ub8/edit

Pivotal Ticket: https://www.pivotaltracker.com/story/show/171143427

They all follow the same template while keeping the same colors/header/etc, except for QMN, which has two extra sections

Here's some screen shots of a few random ones:

![Screen Shot 2020-03-31 at 6 19 54 PM](https://user-images.githubusercontent.com/12496550/78085094-8fdeb700-737f-11ea-98d7-d9c79f50344d.png)
![Screen Shot 2020-03-31 at 4 41 44 PM](https://user-images.githubusercontent.com/12496550/78085096-910fe400-737f-11ea-8d13-711e96f18d72.png)
![Screen Shot 2020-03-31 at 3 16 43 PM](https://user-images.githubusercontent.com/12496550/78085098-92d9a780-737f-11ea-8768-1c8176d79260.png)
![Screen Shot 2020-03-31 at 1 55 09 PM](https://user-images.githubusercontent.com/12496550/78085103-95d49800-737f-11ea-8ca4-20bdb06653e3.png)
![Screen Shot 2020-03-31 at 1 55 02 PM](https://user-images.githubusercontent.com/12496550/78085104-979e5b80-737f-11ea-83d7-8fb84748ec95.png)
![Screen Shot 2020-03-31 at 1 54 45 PM](https://user-images.githubusercontent.com/12496550/78085109-9a00b580-737f-11ea-98de-36e77b776c9d.png)
