### PR TITLE
Labels fallback logic on Promotions

### DIFF
--- a/packages/common/components/style-a/blocks/card-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/card-section-wrapper.marko
@@ -14,7 +14,8 @@ $ const {
   skip,
   buttonStyle,
   buttonTextStyle,
-  teaserStyle
+  teaserStyle,
+  fallbackLabel
 } = input;
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
@@ -61,10 +62,10 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
 
                 <if(node.type === "promotion")>
                   <if(isFull && allowFullPromotion)>
-                    <common-style-a-promotion-full-block node=node alignment=alignment content-link-style=contentLinkStyle teaser-style=teaserStyle />
+                    <common-style-a-promotion-full-block node=node alignment=alignment content-link-style=contentLinkStyle teaser-style=teaserStyle fallback-label=fallbackLabel />
                   </if>
                   <else>
-                    <common-style-a-promotion-block node=node alignment=alignment content-link-style=contentLinkStyle teaser-style=teaserStyle />
+                    <common-style-a-promotion-block node=node alignment=alignment content-link-style=contentLinkStyle teaser-style=teaserStyle fallback-label=fallbackLabel />
                   </else>
                 </if>
                 <else>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -132,7 +132,11 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-full-third-two-thirds-section-wrapper-block>": {
     "template": "./full-third-two-thirds-section-wrapper.marko",
@@ -581,7 +585,11 @@
       "default-value": 300
     },
     "@content-link-style": "object",
-    "@teaser-style": "object"
+    "@teaser-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-promotion-full-block>": {
     "template": "./promotion-full.marko",
@@ -599,7 +607,11 @@
       "default-value": 300
     },
     "@content-link-style": "object",
-    "@teaser-style": "object"
+    "@teaser-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-special-edition-full-wrapper-block>": {
     "template": "./special-edition-full-wrapper.marko",

--- a/packages/common/components/style-a/blocks/promotion-full.marko
+++ b/packages/common/components/style-a/blocks/promotion-full.marko
@@ -5,7 +5,8 @@ $ const {
   node,
   tableWidth,
   imgWidth,
-  alignment
+  alignment,
+  fallbackLabel
 } = input;
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "font-size": "12px",
@@ -25,7 +26,12 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, 'Advertisement')}
+              <if(fallbackLabel == true)>
+                $!{getSponsoredByText(node, 'Advertisement')}
+              </if>
+              <else>
+                $!{getSponsoredByText(node, '&nbsp;')}
+              </else>
             </div>
           </td>
         </tr>

--- a/packages/common/components/style-a/blocks/promotion.marko
+++ b/packages/common/components/style-a/blocks/promotion.marko
@@ -5,7 +5,8 @@ $ const {
   node,
   tableWidth,
   imgWidth,
-  alignment
+  alignment,
+  fallbackLabel
 } = input;
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "font-size": "12px",
@@ -25,7 +26,12 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, 'Advertisement')}
+              <if(fallbackLabel == true)>
+                $!{getSponsoredByText(node, 'Advertisement')}
+              </if>
+              <else>
+                $!{getSponsoredByText(node, '&nbsp;')}
+              </else>
             </div>
           </td>
         </tr>

--- a/packages/common/utils/get-sponsored-by-text.js
+++ b/packages/common/utils/get-sponsored-by-text.js
@@ -3,7 +3,10 @@ const { get } = require('@base-cms/object-path');
 module.exports = (node, fallbackValue = '') => {
   const { labels = [] } = node;
   const sponsored = labels.includes('Sponsored') || labels.includes('Sponsored By');
-  if (!sponsored) return fallbackValue;
   const companyName = get(node, 'company.name');
-  return companyName ? `${labels[0]} ${companyName}` : labels[0];
+  if (sponsored && companyName) {
+    return `Sponsored by ${companyName}`;
+  }
+  const label = labels[0] ? labels[0] : fallbackValue;
+  return label;
 };

--- a/tenants/electronicdesign/templates/ed-update-power-and-analog.marko
+++ b/tenants/electronicdesign/templates/ed-update-power-and-analog.marko
@@ -85,6 +85,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #05 Generic - 2 Column -->
@@ -96,6 +97,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #06 Generic - 1 Column -->
@@ -135,6 +137,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #09 Generic - 2 Column -->
@@ -146,6 +149,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #10 Generic - 1 Column -->
@@ -185,6 +189,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #13 Generic - 2 Column -->
@@ -196,6 +201,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #14 Generic - 1 Column -->
@@ -235,6 +241,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #17 Generic - 2 Column -->
@@ -246,6 +253,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #18 Generic - 1 Column -->
@@ -285,6 +293,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #21 Generic - 2 Column -->
@@ -296,6 +305,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #22 Generic - 1 Column -->

--- a/tenants/electronicdesign/templates/ed-update.marko
+++ b/tenants/electronicdesign/templates/ed-update.marko
@@ -85,6 +85,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #05 Generic - 2 Column -->
@@ -96,6 +97,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #06 Generic - 1 Column -->
@@ -135,6 +137,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #09 Generic - 2 Column -->
@@ -146,6 +149,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #10 Generic - 1 Column -->
@@ -185,6 +189,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #13 Generic - 2 Column -->
@@ -196,6 +201,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #14 Generic - 1 Column -->
@@ -235,6 +241,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #17 Generic - 2 Column -->
@@ -246,6 +253,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #18 Generic - 1 Column -->
@@ -285,6 +293,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #21 Generic - 2 Column -->
@@ -296,6 +305,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #22 Generic - 1 Column -->

--- a/tenants/electronicdesign/templates/embedded-update.marko
+++ b/tenants/electronicdesign/templates/embedded-update.marko
@@ -85,6 +85,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #05 Generic - 2 Column -->
@@ -96,6 +97,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #06 Generic - 1 Column -->
@@ -135,6 +137,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #09 Generic - 2 Column -->
@@ -146,6 +149,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #10 Generic - 1 Column -->
@@ -185,6 +189,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #13 Generic - 2 Column -->
@@ -196,6 +201,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #14 Generic - 1 Column -->
@@ -235,6 +241,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #17 Generic - 2 Column -->
@@ -246,6 +253,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #18 Generic - 1 Column -->
@@ -285,6 +293,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #21 Generic - 2 Column -->
@@ -296,6 +305,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #22 Generic - 1 Column -->

--- a/tenants/machinedesign/templates/special-edition.marko
+++ b/tenants/machinedesign/templates/special-edition.marko
@@ -87,6 +87,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #5 Generic - 2 Column -->
@@ -98,6 +99,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #6 Generic - 1 Column -->
@@ -137,6 +139,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #9 Generic - 2 Column -->
@@ -148,6 +151,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #10 Generic - 1 Column -->
@@ -187,6 +191,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #13 Generic - 2 Column -->
@@ -198,6 +203,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #14 Generic - 1 Column -->
@@ -237,6 +243,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #17 Generic - 2 Column -->
@@ -248,6 +255,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #18 Generic - 1 Column -->
@@ -287,6 +295,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #21 Generic - 2 Column -->
@@ -298,6 +307,7 @@ $ const isFull = false;
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <!-- #22 Generic - 1 Column -->


### PR DESCRIPTION
Relates to: https://www.pivotaltracker.com/story/show/171760118

Electronic Design, Machine Design use promotions almost exclusively in their newsletters and they don’t want the fallback label of “Advertisement” (because it’d be on virtually every content item).  Set fallback label to be configurable so it can be toggled on/off if need-be.

Left: no label, no fallback value.  Right: label "Sponsored"
![Screen Shot 2020-04-22 at 3 18 35 PM](https://user-images.githubusercontent.com/12496550/80032586-023f4480-84b1-11ea-8956-61f25270e0b0.png)

If there’s a label set in Base, return the label, otherwise return the fallbackValue (if `true`).

Also, if the label is “Sponsored” or “Sponsored By” and there’s a Company set on the content in Base, return “Sponsored by [company.name].”
![Screen Shot 2020-04-22 at 2 33 52 PM](https://user-images.githubusercontent.com/12496550/80032607-09fee900-84b1-11ea-803a-9d64c92a79bb.png)

If multiple labels are set, return the first value:

<img width="501" alt="Screen Shot 2020-04-22 at 2 34 51 PM" src="https://user-images.githubusercontent.com/12496550/80032600-0703f880-84b1-11ea-97d0-78811b32248a.png">

