### PR TITLE
Configurable fallbackLabel on Product Spotlight eNLs

### DIFF
--- a/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
+++ b/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
@@ -13,7 +13,8 @@ $ const {
   buttonStyle,
   buttonTextStyle,
   teaserStyle,
-  labelStyle
+  labelStyle,
+  fallbackLabel
 } = input;
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
@@ -60,7 +61,12 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                   <tr>
                     <td>
                       <div style=`${labelStyle}`>
-                        $!{getSponsoredByText(node, fallbackText)}
+                        <if(fallbackLabel == true)>
+                          $!{getSponsoredByText(node, 'Advertisement')}
+                        </if>
+                        <else>
+                          $!{getSponsoredByText(node, '&nbsp;')}
+                        </else>
                       </div>
                     </td>
                   </tr>

--- a/packages/common/components/style-a/blocks/featured-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/featured-section-wrapper.marko
@@ -11,7 +11,8 @@ $ const {
   skip,
   buttonStyle,
   buttonTextStyle,
-  teaserStyle
+  teaserStyle,
+  fallbackLabel
 } = input;
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
@@ -61,6 +62,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     table-width=700
                     content-link-style=contentLinkStyle
                     teaser-style=teaserStyle
+                    fallback-label=fallbackLabel
                   />
                 </if>
                 <else>
@@ -73,6 +75,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     button-style=buttonStyle
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
+                    fallback-label=fallbackLabel
                   />
                 </else>
                 <if(!isLast(nodes, index))>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -31,7 +31,11 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-third-party-featured-section-wrapper-block>": {
     "template": "./third-party-featured-section-wrapper.marko",
@@ -94,7 +98,11 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-card-section-wrapper-block>": {
     "template": "./card-section-wrapper.marko",
@@ -264,7 +272,11 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-third-party-content-180-section-wrapper-block>": {
     "template": "./third-party-content-180-section-wrapper.marko",
@@ -403,7 +415,11 @@
     "@content-link-style": "object",
     "@teaser-style": "object",
     "@button-style": "string",
-    "@button-text-style": "object"
+    "@button-text-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-simple-card-full-block>": {
     "template": "./simple-card-full.marko",
@@ -513,7 +529,11 @@
     "@content-link-style": "object",
     "@teaser-style": "object",
     "@button-style": "string",
-    "@button-text-style": "object"
+    "@button-text-style": "object",
+    "@fallback-label": {
+      "type": "boolean",
+      "default-value":true
+    }
   },
   "<common-style-a-third-party-content-180-block>": {
     "template": "./third-party-content-180.marko",

--- a/packages/common/components/style-a/blocks/product-spotlight-180-section-wrapper.marko
+++ b/packages/common/components/style-a/blocks/product-spotlight-180-section-wrapper.marko
@@ -11,7 +11,8 @@ $ const {
   skip,
   buttonStyle,
   buttonTextStyle,
-  teaserStyle
+  teaserStyle,
+  fallbackLabel
 } = input;
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font-family: Garamond, serif; font-size: 13px; line-height: 21px; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: #00b398; background-color: #ffffff; border-bottom: 3px solid #d7d7d7; border-top: 4px solid #00b398;");
 $ const titleStyle = defaultValue(input.titleStyle, "font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; margin-top: 9px; margin-left: 20px; margin-bottom: 9px; font-weight: bold;");
@@ -60,6 +61,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     button-style=buttonStyle
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
+                    fallback-label=fallbackLabel
                   />
                 </if>
                 <else>
@@ -70,6 +72,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
                     show-title=true
+                    fallback-label=fallbackLabel
                   />
                 </else>
                 <if(!isLast(nodes, index))>

--- a/packages/common/components/style-a/blocks/product-spotlight-180.marko
+++ b/packages/common/components/style-a/blocks/product-spotlight-180.marko
@@ -6,7 +6,8 @@ $ const {
   node,
   imageAlignment,
   showTitle,
-  showButton
+  showButton,
+  fallbackLabel
 } = input;
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "font-size": "12px",
@@ -45,7 +46,12 @@ $ const teaserField = node.type === 'promotion' ? 'body' : 'teaser';
     <tr>
       <td>
         <div style=`padding-left: ${innerPadding}px; font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;`>
-          $!{getSponsoredByText(node, fallbackText)}
+          <if(fallbackLabel == true)>
+            $!{getSponsoredByText(node, 'Advertisement')}
+          </if>
+          <else>
+            $!{getSponsoredByText(node, '&nbsp;')}
+          </else>
         </div>
       </td>
     </tr>
@@ -105,7 +111,12 @@ $ const teaserField = node.type === 'promotion' ? 'body' : 'teaser';
     <tr>
       <td>
         <div style=`padding-left: ${innerPadding}px; font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;`>
-          $!{getSponsoredByText(node, fallbackText)}
+          <if(fallbackLabel == true)>
+            $!{getSponsoredByText(node, 'Advertisement')}
+          </if>
+          <else>
+            $!{getSponsoredByText(node, '&nbsp;')}
+          </else>
         </div>
       </td>
     </tr>

--- a/packages/common/components/style-a/blocks/simple-card.marko
+++ b/packages/common/components/style-a/blocks/simple-card.marko
@@ -7,6 +7,7 @@ $ const {
   alignment,
   tableWidth,
   imgWidth,
+  fallbackLabel
 } = input;
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "font-size": "12px",
@@ -45,7 +46,12 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
         <tr>
           <td>
             <div style=" font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;">
-              $!{getSponsoredByText(node, '&nbsp;')}
+              <if(fallbackLabel == true)>
+                $!{getSponsoredByText(node, 'Advertisement')}
+              </if>
+              <else>
+                $!{getSponsoredByText(node, '&nbsp;')}
+              </else>
             </div>
           </td>
         </tr>

--- a/tenants/electronicdesign/templates/product-spotlight.marko
+++ b/tenants/electronicdesign/templates/product-spotlight.marko
@@ -47,6 +47,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />

--- a/tenants/hydraulicspneumatics/templates/product-source.marko
+++ b/tenants/hydraulicspneumatics/templates/product-source.marko
@@ -76,6 +76,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />

--- a/tenants/machinedesign/templates/product-spotlight.marko
+++ b/tenants/machinedesign/templates/product-spotlight.marko
@@ -49,6 +49,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />

--- a/tenants/mwrf/templates/product-spotlight.marko
+++ b/tenants/mwrf/templates/product-spotlight.marko
@@ -76,6 +76,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />

--- a/tenants/sourcetoday/templates/source-today.marko
+++ b/tenants/sourcetoday/templates/source-today.marko
@@ -62,6 +62,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />
@@ -77,6 +78,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />
@@ -90,6 +92,7 @@ $ const buttonTextStyle = {
       content-link-style=contentLinkStyle
       button-style=featuredButtonStyle
       button-text-style=featuredButtonTextStyle
+      fallback-label=false
     />
 
     <common-section-spacer-element />


### PR DESCRIPTION
Piggybacking off of #150 

After, no labels set:
![Screen Shot 2020-04-30 at 1 17 54 PM](https://user-images.githubusercontent.com/12496550/80746590-bcedc900-8ae7-11ea-9815-1c0904699417.png)

Before, no labels set, Advertisement fallback text
![Screen Shot 2020-04-30 at 1 18 01 PM](https://user-images.githubusercontent.com/12496550/80746621-cc6d1200-8ae7-11ea-8eb1-d335fa9b1527.png)
