### PR TITLE
Set Advertisement label for Promotions

### DIFF
--- a/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
+++ b/packages/common/components/style-a/blocks/featured-ad-wrapper.marko
@@ -62,7 +62,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     <td>
                       <div style=`${labelStyle}`>
                         <if(fallbackLabel == true)>
-                          $!{getSponsoredByText(node, 'Advertisement')}
+                          $!{getSponsoredByText(node, fallbackText)}
                         </if>
                         <else>
                           $!{getSponsoredByText(node, '&nbsp;')}

--- a/packages/common/components/style-a/blocks/product-spotlight-180.marko
+++ b/packages/common/components/style-a/blocks/product-spotlight-180.marko
@@ -47,7 +47,7 @@ $ const teaserField = node.type === 'promotion' ? 'body' : 'teaser';
       <td>
         <div style=`padding-left: ${innerPadding}px; font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;`>
           <if(fallbackLabel == true)>
-            $!{getSponsoredByText(node, 'Advertisement')}
+            $!{getSponsoredByText(node, fallbackText)}
           </if>
           <else>
             $!{getSponsoredByText(node, '&nbsp;')}
@@ -112,7 +112,7 @@ $ const teaserField = node.type === 'promotion' ? 'body' : 'teaser';
       <td>
         <div style=`padding-left: ${innerPadding}px; font-weight: normal; color: #6b6b6b; font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif; font-size: 11px;`>
           <if(fallbackLabel == true)>
-            $!{getSponsoredByText(node, 'Advertisement')}
+            $!{getSponsoredByText(node, fallbackText)}
           </if>
           <else>
             $!{getSponsoredByText(node, '&nbsp;')}


### PR DESCRIPTION
If fallbackLabel is true (is by default) AND the content is a promotion, then set the advertisement label above content:

![image](https://user-images.githubusercontent.com/12496550/80819453-a2285c80-8b9a-11ea-8552-3777b92749bb.png)
