### PR TITLE
Update leaderboard_primary size

### DIFF
--- a/tenants/processingmagazine/config/email-x.js
+++ b/tenants/processingmagazine/config/email-x.js
@@ -6,8 +6,8 @@ config
     {
       name: 'leaderboardPrimary',
       id: '5e8c95aa8a13ab55db38acd4',
-      width: 670,
-      height: 90,
+      width: 600,
+      height: 100,
     },
     {
       name: 'mrPrimary',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173247267

Standardizing to the 600x100:
![Screen Shot 2020-06-09 at 11 48 32 AM](https://user-images.githubusercontent.com/12496550/84195207-cc0b5380-aa63-11ea-92d0-e1ab5463e6c3.png)
