### PR TITLE
PSC Block

### DIFF
--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -155,7 +155,11 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@psc": {
+      "type": "boolean",
+      "default-value":false
+    }
   },
   "<common-style-b-promo-card-block>": {
     "template": "./promo-card.marko",
@@ -176,6 +180,27 @@
       "default-value": 355
     },
     "@teaser-style": "object"
+  },
+  "<common-style-b-psc-card-block>": {
+    "template": "./psc-card.marko",
+    "@alignment": {
+      "type": "string",
+      "default-value": "left"
+    },
+    "@button-style": "string",
+    "@button-text-style": "object",
+    "@content-link-style": "object",
+    "@img-width": {
+      "type": "number",
+      "default-value": 300
+    },
+    "@node": "object",
+    "@table-width": {
+      "type": "number",
+      "default-value": 355
+    },
+    "@teaser-style": "object",
+    "@images" : "array"
   },
   "<common-style-b-full-section-wrapper-block>": {
     "template": "./full-section-wrapper.marko",

--- a/packages/common/components/style-b/blocks/psc-card.marko
+++ b/packages/common/components/style-b/blocks/psc-card.marko
@@ -1,23 +1,5 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 import { getAsArray } from "@base-cms/object-path";
-import { buildImgixUrl } from "@base-cms/image";
-
-
-<!-- $ const imageOptions = {
-  ar: "16:9",
-  fit: "crop",
-  crop: "focalpoint",
-  fpX: 0.5,
-  fpY: 0.5,
-  w: 150,
-}; -->
-
-<!-- $ const images = getAsArray(input, "images.edges").map(({ node }) => node); -->
-<!-- $ const images = getAsArray(input, "images").map(node => {
-  const isLogo = Boolean(node.isLogo);
-  return { ...node};
-}); -->
-
 
 $ const {
   alignment,
@@ -69,33 +51,31 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
                     </marko-core-obj-value>
                   </td>
                 </tr>
-                <tr>
-                  <td>&nbsp;</td>
-                </tr>
-                <tr>
-                  <td align="center">
 
-                  $ const images = getAsArray(input, "images.edges").map(({ node }) => node);
+                $ const images = getAsArray(node, "images.edges").map(({ node }) => node);
 
-                    <for|image| of=images>
-                    $ console.log(image)
-                     <if(primaryImage.id !== image.id)>
-                     <p>testing</p>
-                        <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                <for|image| of=images>
+                  <if(node.primaryImage.id !== image.id)>
+                    <tr>
+                      <td>&nbsp;</td>
+                    </tr>
+                    <tr>
+                      <td align="center">
+                        <a href=node.siteContext.url target="_blank" >
                           <marko-newsletter-imgix
                             src=image.src
                             alt=image.alt
-                            options={ w: 180 }
+                            options={ w: 150 }
                             class="main"
-                            attrs={ border: 0, width: 180 }
+                            attrs={ border: 0, width: 150 }
                           >
-                            <@link href=node.siteContext.url target="_blank" />
-                          </marko-newsletter-imgix>
-                        </marko-core-obj-value>
-                      </if>
-                    </for>
-                  </td>
-                </tr>
+                        </marko-newsletter-imgix>
+                        </a>
+                      </td>
+                    </tr>
+                  </if>
+                </for>
+
               </common-table>
             </td>
           </tr>

--- a/packages/common/components/style-b/blocks/psc-card.marko
+++ b/packages/common/components/style-b/blocks/psc-card.marko
@@ -66,7 +66,6 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
                             src=image.src
                             alt=image.alt
                             options={ w: 150 }
-                            class="main"
                             attrs={ border: 0, width: 150 }
                           >
                         </marko-newsletter-imgix>

--- a/packages/common/components/style-b/blocks/psc-card.marko
+++ b/packages/common/components/style-b/blocks/psc-card.marko
@@ -1,0 +1,179 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+import { getAsArray } from "@base-cms/object-path";
+import { buildImgixUrl } from "@base-cms/image";
+
+
+<!-- $ const imageOptions = {
+  ar: "16:9",
+  fit: "crop",
+  crop: "focalpoint",
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 150,
+}; -->
+
+<!-- $ const images = getAsArray(input, "images.edges").map(({ node }) => node); -->
+<!-- $ const images = getAsArray(input, "images").map(node => {
+  const isLogo = Boolean(node.isLogo);
+  return { ...node};
+}); -->
+
+
+$ const {
+  alignment,
+  imgWidth,
+  node,
+  tableWidth,
+} = input;
+
+$ const teaserStyle = defaultValue(input.teaserStyle, {
+  "color": "#666",
+  "font": "normal 13px/15px sans-serif",
+  "margin": "0",
+  "padding": "0"
+});
+$ const buttonStyle = defaultValue(input.buttonStyle, "background-color: #000; padding: 5px 20px;");
+$ const buttonTextStyle = defaultValue(input.buttonTextStyle, {
+  "color": "#fff",
+  "font": "bold 16px/24px sans-serif"
+});
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "font": "bold 18px sans-serif",
+  "color": "#145d8e",
+  "text-decoration": "none"
+});
+
+$ const innerPadding = 20;
+$ const innerTableWidth = tableWidth - (innerPadding * 2);
+
+<if(node.primaryImage)>
+  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" class="main promo-card" padding=0 spacing=0>
+    <tr>
+      <td>
+        <common-table style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main promo-card__image" padding=0 spacing=0>
+          <tr>
+            <td style=`padding-top: ${innerPadding}px; padding-right: 0; padding-bottom: ${innerPadding}px; padding-left: ${innerPadding}px;`>
+              <common-table width=300 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
+                <tr>
+                  <td>
+                    <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                      <marko-newsletter-imgix
+                        src=image.src
+                        alt=image.alt
+                        options={ w: imgWidth }
+                        class="main"
+                        attrs={ border: 0, width: imgWidth }
+                      >
+                        <@link href=node.siteContext.url target="_blank" />
+                      </marko-newsletter-imgix>
+                    </marko-core-obj-value>
+                  </td>
+                </tr>
+                <tr>
+                  <td>&nbsp;</td>
+                </tr>
+                <tr>
+                  <td align="center">
+
+                  $ const images = getAsArray(input, "images.edges").map(({ node }) => node);
+
+                    <for|image| of=images>
+                    $ console.log(image)
+                     <if(primaryImage.id !== image.id)>
+                     <p>testing</p>
+                        <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                          <marko-newsletter-imgix
+                            src=image.src
+                            alt=image.alt
+                            options={ w: 180 }
+                            class="main"
+                            attrs={ border: 0, width: 180 }
+                          >
+                            <@link href=node.siteContext.url target="_blank" />
+                          </marko-newsletter-imgix>
+                        </marko-core-obj-value>
+                      </if>
+                    </for>
+                  </td>
+                </tr>
+              </common-table>
+            </td>
+          </tr>
+        </common-table>
+
+        <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="right" class="main right promo-card__content" padding=0 spacing=0>
+          <tr>
+            <td style=`padding-top: ${innerPadding}px; padding-left: 0; padding-bottom: ${innerPadding}px; padding-right: ${innerPadding}px;`>
+              <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
+                <tr>
+                  <td>
+                    <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                      <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                    </marko-core-obj-text>
+                  </td>
+                </tr>
+                <tr>
+                  <td>&nbsp;</td>
+                </tr>
+                <tr>
+                  <td>
+                    <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                  </td>
+                </tr>
+                <tr>
+                  <td>&nbsp;</td>
+                </tr>
+                <tr>
+                  <td align="center">
+                    <common-button-element
+                      button-style=buttonStyle
+                      button-text-style=buttonTextStyle
+                      node=node
+                    />
+                  </td>
+                </tr>
+              </common-table>
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+</if>
+<else>
+  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" class="main promo-card" padding=0 spacing=0>
+    <tr>
+      <td style=`padding: ${innerPadding}px;`>
+        <common-table width="100%" style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="center" padding=0 spacing=0>
+          <tr>
+            <td>
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+              </marko-core-obj-text>
+            </td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>
+              <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+            </td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td align="center">
+              <common-button-element
+                button-style=buttonStyle
+                button-text-style=buttonTextStyle
+                node=node
+              />
+            </td>
+          </tr>
+        </common-table>
+      </td>
+    </tr>
+  </common-table>
+</else>

--- a/packages/common/components/style-b/blocks/text-promo-wrapper.marko
+++ b/packages/common/components/style-b/blocks/text-promo-wrapper.marko
@@ -9,6 +9,7 @@ $ const {
   newsletter,
   sectionId,
   skip,
+  psc
 } = input;
 
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font: normal 12px/18px sans-serif; margin: 0; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
@@ -41,14 +42,26 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
         queryFragment: contentList,
       }>
         <for|node, index| of=nodes>
-          <if(!isFirst(nodes, index))>
-            <common-table width="700" class="main" padding=10 spacing=0>
-              &nbsp;
+          <if(!isFirst(nodes, index) && !psc)>
+            <common-table width="100%" class="main" padding=0 spacing=0>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
             </common-table>
           </if>
-          <common-table width="700" align="left"  style=`${mainTableStyle}` class="main" padding=0 spacing=0>
+          <common-table width="700" align="center"  style=`${mainTableStyle}` class="main" padding=0 spacing=0>
             <tr>
               <td valign="top">
+                <if(psc)>
+                  <common-style-b-psc-card-block
+                    node=node
+                    content-link-style=contentLinkStyle
+                    button-style=buttonStyle
+                    button-text-style=buttonTextStyle
+                    teaser-style=teaserStyle
+                  />
+                </if>
+                <else>
                   <common-style-b-promo-card-block
                     node=node
                     content-link-style=contentLinkStyle
@@ -56,12 +69,15 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
                   />
+                </else>
               </td>
             </tr>
           </common-table>
-          <if(isLast(nodes, index))>
-            <common-table width="700" class="main" padding=10 spacing=0>
-              &nbsp;
+          <if(isLast(nodes, index) && psc)>
+            <common-table width="100%" class="main" padding=0 spacing=0>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
             </common-table>
           </if>
         </for>

--- a/packages/common/graphql/fragments/content-list.js
+++ b/packages/common/graphql/fragments/content-list.js
@@ -13,6 +13,16 @@ fragment NewsletterContentListFragment on Content {
     src
     alt
   }
+  images {
+    edges {
+      node {
+        id
+        src
+        alt
+        isLogo
+      }
+    }
+  }
   labels
   company {
     id

--- a/tenants/dentaleconomics/templates/m90-product-newsletter.marko
+++ b/tenants/dentaleconomics/templates/m90-product-newsletter.marko
@@ -6,11 +6,12 @@ $ const buttonTextStyle = {
   "font": "bold 16px/24px sans-serif"
 };
 $ const contentLinkStyle = {
-  "font": "bold 18px/27px sans-serif",
-  "color": "#30659A"
+  "font": "bold 18px sans-serif",
+  "color": "#145d8e",
+  "text-decoration": "none"
 };
-$ const featuredMainTableStyle = "background-color: #ebebeb;";
-$ const footerStyle = "background-color: #515151; color: #fff;";
+$ const featuredMainTableStyle = "border: 10px solid #ecedee;";
+$ const footerStyle = "background-color: #383838; color: #fff;";
 
 <marko-newsletter-root
   title=newsletter.name
@@ -30,8 +31,6 @@ $ const footerStyle = "background-color: #515151; color: #fff;";
           />
           <common-style-b-image-only-header-block image-path="/files/base/ebm/de/image/static/newsletter/m90-product-newsletter_header.jpg" date=date newsletter=newsletter />
 
-          <common-section-spacer-element />
-
           <common-style-b-text-promo-wrapper
             section-id=35653
             date=date
@@ -40,6 +39,7 @@ $ const footerStyle = "background-color: #515151; color: #fff;";
             button-text-style=buttonTextStyle
             content-link-style=contentLinkStyle
             main-table-style=featuredMainTableStyle
+            psc=true
           />
 
           <common-style-b-footer-nav-block


### PR DESCRIPTION
New block that mimics the functionality of the legacy Product Showcase template.  Primary image at 300px wide, with a smaller 150px image below.  The Corona product has a second image uploaded to Base as an example:
![image](https://user-images.githubusercontent.com/12496550/85320714-1c81a880-b489-11ea-9f8b-8bc850cc568b.png)
