### PR TITLE
Footer `style-b` adjustments

### DIFF
--- a/packages/common/components/style-b/blocks/footer-nav.marko
+++ b/packages/common/components/style-b/blocks/footer-nav.marko
@@ -2,12 +2,10 @@ import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const footerStyle = defaultValue(input.footerStyle, "background-color: #000;");
 
-<common-table width="700" align="center" class="main footer-nav" style=`${footerStyle}` padding=0 spacing=0 >
+<common-table width="700" align="center" class="main footer-nav" style=`${footerStyle}` padding=10 spacing=0 >
   <tr>
-    <td align="left">
+    <td>
       <common-style-b-brand-nav-element />
-    </td>
-    <td align="right">
       <common-style-b-copyright-element />
     </td>
   </tr>

--- a/packages/common/components/style-b/blocks/footer-nav.marko
+++ b/packages/common/components/style-b/blocks/footer-nav.marko
@@ -1,6 +1,6 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
-$ const footerStyle = defaultValue(input.footerStyle, "background-color: #000; color: #fff;");
+$ const footerStyle = defaultValue(input.footerStyle, "background-color: #000;");
 
 <common-table width="700" align="center" class="main footer-nav" style=`${footerStyle}` padding=0 spacing=0 >
   <tr>

--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -4,7 +4,7 @@
   },
   "<common-style-b-footer-nav-block>": {
     "template": "./footer-nav.marko",
-    "@footer-style" : "object"
+    "@footer-style" : "string"
   },
   "<common-style-b-simple-card-block>": {
     "template": "./simple-card.marko",

--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -3,7 +3,8 @@
     "template": "./opt-out.marko"
   },
   "<common-style-b-footer-nav-block>": {
-    "template": "./footer-nav.marko"
+    "template": "./footer-nav.marko",
+    "@footer-style" : "object"
   },
   "<common-style-b-simple-card-block>": {
     "template": "./simple-card.marko",

--- a/packages/common/components/style-b/default-style.marko
+++ b/packages/common/components/style-b/default-style.marko
@@ -8,24 +8,6 @@
 <![endif]-->
 
 <style type="text/css">
-  .brand-nav-list {
-    padding: 0 10px;
-  }
-  .brand-nav-list:first-child {
-    padding: 0 10px 0 0;
-  }
-  .copyright,
-  .brand-nav-list__link {
-    color: #fff;
-    font: normal 12px/18px Arial, 'Helvetica Neue', Helvetica, sans-serif;
-    text-decoration: none;
-  }
-
-  .footer-nav {
-    font: normal 12px/18px Arial, 'Helvetica Neue', Helvetica, sans-serif;
-    padding: 5px 10px;
-  }
-
   body p b,
   body p a {
     color: #000000;
@@ -51,6 +33,9 @@
     /* mobile-specific CSS styles go here */
     .top {
       width: 340px !important;
+    }
+    .center {
+      text-align: center !important;
     }
     .scaleAd,
     .scaleAd img {

--- a/packages/common/components/style-b/elements/brand-nav.marko
+++ b/packages/common/components/style-b/elements/brand-nav.marko
@@ -5,15 +5,18 @@ import { asObject } from "@base-cms/utils";
 $ const { config } = out.global;
 $ const brandNav = config.getAsArray('brandNavLinks');
 
-<common-table width="100%" class="brand-nav" padding=0 spacing=0>
 $ const footerFontStyle = defaultValue(input.footerFontStyle, "color: #fff; text-decoration: none !important; text-align:left; font: 12px Arial, Helvetica, sans-serif;");
+
+<common-table align="left" width="345" padding=0 spacing=0>
   <tr>
-  <for|brandNavLinks| of=brandNav>
-    <td class="brand-nav-list">
-      <a class="brand-nav-list__link" href=brandNavLinks.href target="_blank">
-        ${brandNavLinks.title}
-      </a>
+    <td>
+      <div style=`${footerFontStyle}` class="center">
+        <for|brandNavLinks| of=brandNav>
+          <a style=`${footerFontStyle}` href=brandNavLinks.href target="_blank">
+            ${brandNavLinks.title}  &nbsp;&nbsp;
+          </a>
+        </for>
+      </div>
     </td>
-  </for>
   </tr>
 </common-table>

--- a/packages/common/components/style-b/elements/brand-nav.marko
+++ b/packages/common/components/style-b/elements/brand-nav.marko
@@ -1,3 +1,4 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 import { getAsArray } from "@base-cms/object-path";
 import { asObject } from "@base-cms/utils";
 
@@ -5,6 +6,7 @@ $ const { config } = out.global;
 $ const brandNav = config.getAsArray('brandNavLinks');
 
 <common-table width="100%" class="brand-nav" padding=0 spacing=0>
+$ const footerFontStyle = defaultValue(input.footerFontStyle, "color: #fff; text-decoration: none !important; text-align:left; font: 12px Arial, Helvetica, sans-serif;");
   <tr>
   <for|brandNavLinks| of=brandNav>
     <td class="brand-nav-list">

--- a/packages/common/components/style-b/elements/copyright.marko
+++ b/packages/common/components/style-b/elements/copyright.marko
@@ -4,6 +4,14 @@ $ const company = "Endeavor Business Media, LLC.";
 $ const copyrightText = "All rights reserved.";
 $ const copyrightFontStyle = defaultValue(input.copyrightFontStyle, "color: #fff; text-decoration: none !important; text-align:left; font: 12px Arial, Helvetica, sans-serif;");
 
-<span class="copyright">
-  &copy; ${year} ${company} ${copyrightText}
-</span>
+<common-table align="right" class="main" width="325" padding=0 spacing=0>
+  <tr>
+    <td>
+      <div style=`${copyrightFontStyle}` class="center">
+        <span style=`${copyrightFontStyle}`>
+          &copy; ${year} ${company} ${copyrightText}
+        </span>
+      </div>
+    </td>
+  </tr>
+</common-table>

--- a/packages/common/components/style-b/elements/copyright.marko
+++ b/packages/common/components/style-b/elements/copyright.marko
@@ -1,6 +1,8 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 $ const year = new Date().getFullYear();
 $ const company = "Endeavor Business Media, LLC.";
 $ const copyrightText = "All rights reserved.";
+$ const copyrightFontStyle = defaultValue(input.copyrightFontStyle, "color: #fff; text-decoration: none !important; text-align:left; font: 12px Arial, Helvetica, sans-serif;");
 
 <span class="copyright">
   &copy; ${year} ${company} ${copyrightText}

--- a/packages/common/components/style-b/elements/marko.json
+++ b/packages/common/components/style-b/elements/marko.json
@@ -1,9 +1,10 @@
 {
   "<common-style-b-copyright-element>": {
-    "template": "./copyright.marko"
+    "template": "./copyright.marko",
+    "@copyright-font-style": "object"
   },
   "<common-style-b-brand-nav-element>": {
     "template": "./brand-nav.marko",
-    "@footer-style": "string"
+    "@footer-font-style": "object"
   }
 }

--- a/packages/common/components/style-b/elements/marko.json
+++ b/packages/common/components/style-b/elements/marko.json
@@ -1,10 +1,10 @@
 {
   "<common-style-b-copyright-element>": {
     "template": "./copyright.marko",
-    "@copyright-font-style": "object"
+    "@copyright-font-style": "string"
   },
   "<common-style-b-brand-nav-element>": {
     "template": "./brand-nav.marko",
-    "@footer-font-style": "object"
+    "@footer-font-style": "string"
   }
 }

--- a/tenants/dentaleconomics/templates/m90-product-newsletter.marko
+++ b/tenants/dentaleconomics/templates/m90-product-newsletter.marko
@@ -11,7 +11,7 @@ $ const contentLinkStyle = {
   "text-decoration": "none"
 };
 $ const featuredMainTableStyle = "border: 10px solid #ecedee;";
-$ const footerStyle = "background-color: #383838; color: #fff;";
+$ const footerStyle = "background-color: #383838; text-decoration: none !important;";
 
 <marko-newsletter-root
   title=newsletter.name


### PR DESCRIPTION
1. Modified the newsletter footer for additional customization options:
- Generic `footerStyle` that has the background-color and other misc styles
- `copyrightFontStyle` that styles the copyright text exclusively
- `footerFontStyle` for the nav item font styles
2. Moved the css styles inline
Gmail is really hit-or-miss when it comes to stylesheets, so it’s generally best practice to try and put as many styles inline as possible.
3. Minor table structure adjustments for email client compatibility:

![Screen Shot 2020-06-22 at 2 40 34 PM](https://user-images.githubusercontent.com/12496550/85330198-8609b300-b499-11ea-92dd-f9fd7790075c.png)
![Screen Shot 2020-06-22 at 2 41 55 PM](https://user-images.githubusercontent.com/12496550/85330200-873ae000-b499-11ea-9e9c-f0c59e782c9e.png)
![Screen Shot 2020-06-22 at 2 42 28 PM](https://user-images.githubusercontent.com/12496550/85330205-886c0d00-b499-11ea-9464-4302e7d9cea2.png)
![Screen Shot 2020-06-22 at 2 46 39 PM](https://user-images.githubusercontent.com/12496550/85330208-899d3a00-b499-11ea-8b25-a21e68ef265b.png)
