### PR TITLE
New hr component

### DIFF
--- a/packages/common/components/elements/hr.marko
+++ b/packages/common/components/elements/hr.marko
@@ -1,0 +1,15 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  hrColor,
+  hrHeight
+} = input;
+
+<table width="720" padding="0" spacing="0" align="center" style="border-collapse:collapse;" class="main">
+  <tr>
+    <td height=hrHeight bgcolor=hrColor></td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+  </tr>
+</table>

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -10,6 +10,17 @@
   "<common-section-spacer-element>": {
     "template": "./section-spacer.marko"
   },
+  "<common-hr-element>": {
+    "template": "./hr.marko",
+    "@hr-color": {
+      "type": "string",
+      "default-value": "#666"
+    },
+    "@hr-height": {
+      "type": "number",
+      "default-value": "0"
+    }
+  },
   "<common-banner-element>": {
     "template": "./banner.marko",
     "@name": "string",

--- a/packages/common/components/style-b/elements/brand-nav.marko
+++ b/packages/common/components/style-b/elements/brand-nav.marko
@@ -13,7 +13,7 @@ $ const footerFontStyle = defaultValue(input.footerFontStyle, "color: #fff; text
       <div style=`${footerFontStyle}` class="center">
         <for|brandNavLinks| of=brandNav>
           <a style=`${footerFontStyle}` href=brandNavLinks.href target="_blank">
-            ${brandNavLinks.title}  &nbsp;&nbsp;
+            &nbsp; ${brandNavLinks.title} &nbsp;
           </a>
         </for>
       </div>


### PR DESCRIPTION
Relates to the “Custom Separator” we used in the legacy newsletters, this will allow you to add something like `<common-hr-element hr-color=hrColor />` between blocks in a newsletter

Example of blue hr between blocks in a newsletter:
![image](https://user-images.githubusercontent.com/12496550/86048264-d773ee00-ba15-11ea-908b-5628228994e3.png)
