### PR TITLE
Update block on MWRF Today eNL

### DIFF
--- a/tenants/mwrf/templates/today.marko
+++ b/tenants/mwrf/templates/today.marko
@@ -41,7 +41,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-featured-section-wrapper-block
+    <common-style-a-third-party-featured-section-wrapper-block
       section-id=74543
       date=date
       limit=1


### PR DESCRIPTION
They’d like their “Featured” block to match Electronic Design Today’s: https://newsletters.electronicdesign.com/templates/electronic-design-today?date=1591851600000

Copied template used in ED Today over to MWRF Today

https://www.pivotaltracker.com/story/show/173542042

![Screen Shot 2020-06-29 at 2 50 57 PM](https://user-images.githubusercontent.com/12496550/86049694-36d2fd80-ba18-11ea-8ff1-356ed394c3a8.png)
