### PR TITLE
Matched the simple-cards to editor body html settings

### DIFF
--- a/packages/common/components/style-a/blocks/simple-card-full.marko
+++ b/packages/common/components/style-a/blocks/simple-card-full.marko
@@ -35,7 +35,7 @@ $ const innerPadding = 20;
 $ const innerTableWidth = tableWidth - (innerPadding * 2);
 
 <if(node.primaryImage && displayImage)>
-  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left main" padding=0 spacing=0>
+  <common-table class="simple-card-full__with-image left main" width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" padding=0 spacing=0>
     <tr>
       <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: 0px;`>
         <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left main" padding=0 spacing=0>
@@ -75,14 +75,14 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
           </tr>
           <tr>
             <td style="padding-bottom: 5px;">
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+              <marko-core-obj-text tag="h3" obj=node field="name" attrs={ style: { "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
             </td>
           </tr>
           <tr>
              <td style=teaserWrapperStyle >
-              <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </td>
           </tr>
         </common-table>
@@ -116,17 +116,17 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
   </common-table>
 </if>
 <else>
-  <common-table width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+  <common-table class="simple-card-full left main" width="100%" style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" padding=0 spacing=0>
     <tr>
       <td style=`padding: ${innerPadding}px;`>
-        <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+        <marko-core-obj-text tag="h3" obj=node field="name" attrs={ style: { "text-align": "left" } } >
           <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
         </marko-core-obj-text>
       </td>
     </tr>
     <tr>
       <td style=teaserWrapperStyle style="padding: 0 20px;">
-        <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+        <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
       </td>
     </tr>
     <if(showButton)>

--- a/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
+++ b/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = defaultValue(input.buttonTextStyle, {
 $ const innerPadding = 20;
 
 <if(node.primaryImage)>
-  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+  <common-table class="simple-card-third-two-thirds__with-image" width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
     <tr>
       <td style=`padding: 0; padding-left: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
         <common-table width=260 style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="left" class="left" padding=0 spacing=0>
@@ -87,15 +87,13 @@ $ const innerPadding = 20;
   </common-table>
 </if>
 <else>
-  <common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
+  <common-table class="simple-card-third-two-thirds" width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align="left" class="left" padding=0 spacing=0>
     <tr>
       <td style=`padding: ${innerPadding}px;`>
-        <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+        <marko-core-obj-text tag="h3" obj=node field="name" attrs={ style: { "text-align": "left" } } >
           <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
         </marko-core-obj-text>
-        <div height="10" style="font-size: 10px; margin: 0; padding: 0;">&nbsp;</div>
-        <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
-
+        <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
         <common-table style=`padding-top: ${innerPadding}px;` align="center" padding=0 spacing=0>
           <tr>
             <td style=`${buttonStyle}`>

--- a/packages/common/components/style-a/blocks/simple-card.marko
+++ b/packages/common/components/style-a/blocks/simple-card.marko
@@ -33,7 +33,7 @@ $ const buttonTextStyle = defaultValue(input.buttonTextStyle, {
 $ const innerPadding = 20;
 $ const innerTableWidth = tableWidth - (innerPadding * 2);
 
-<common-table width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align=alignment class=`${alignment} main` padding=0 spacing=0>
+<common-table class=`simple-card ${alignment} main` width=tableWidth style="border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;" align=alignment padding=0 spacing=0>
   <tr>
     <td style=`padding: 0; padding-${alignment}: ${innerPadding}px; padding-bottom: ${innerPadding}px;`>
       <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align=alignment class=`${alignment} main` padding=0 spacing=0>
@@ -65,11 +65,10 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
               </marko-core-obj-value>
             </if>
 
-            <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+            <marko-core-obj-text tag="h3" obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
               <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
             </marko-core-obj-text>
-            <div height="10">&nbsp;</div>
-            <marko-core-obj-text tag="span" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+            <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             <common-table align="center" padding=0 spacing=0>
               <tr>
                 <td>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173504758

Update the html tags on the simple cards to match the WYSIWG tags from the body used by promotion content.
Also added class names to the table wrappers to help with component trouble-shooting in the future.