### PR TITLE
Padding fix of `titleStyle` in style-b/full-section-wrapper

### DIFF
--- a/packages/common/components/style-b/blocks/full-section-wrapper.marko
+++ b/packages/common/components/style-b/blocks/full-section-wrapper.marko
@@ -13,7 +13,7 @@ $ const {
   imgWidth,
   tableWidth
 } = input;
-$ const titleStyle = defaultValue(input.titleStyle, "font: bold 16px/24px 'Helvetica Neue', Helvetica, sans-serif; margin: 0;, padding: 5px 10px;");
+$ const titleStyle = defaultValue(input.titleStyle, "font: bold 16px/24px 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 5px 10px;");
 $ const titleTableStyle = defaultValue(input.titleTableStyle, titleStyle + "table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #000; background-color: #ffffff;");
 $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:collapse; font: bold 16px/24px 'Helvetica Neue', Helvetica, sans-serif; margin: 0; background-color: #ffffff; mso-table-lspace: 0pt; mso-table-rspace: 0pt;");
 $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {

--- a/tenants/flowcontrolnetwork/templates/weekly-update.marko
+++ b/tenants/flowcontrolnetwork/templates/weekly-update.marko
@@ -5,7 +5,7 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
 $ const mrPrimary = emailX.getAdUnit({ name: "mrPrimary", alias: newsletter.alias });
 $ const mrSecondary = emailX.getAdUnit({ name: "mrSecondary", alias: newsletter.alias });
 
-$ const titleStyle = "font: bold 20px/30px 'Helvetica Neue', Helvetica, sans-serif; margin: 0;";
+$ const titleStyle = "font: bold 20px/30px 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 5px 10px;";
 $ const titleTableStyle = titleStyle + "table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #fff; background-color: #CB011B;";
 $ const featuredMainTableStyle = "background-color: #ebebeb";
 $ const contentLinkStyle = {

--- a/tenants/processingmagazine/templates/processing-weekly-update.marko
+++ b/tenants/processingmagazine/templates/processing-weekly-update.marko
@@ -5,7 +5,7 @@ $ const leaderboardPrimary = emailX.getAdUnit({ name: "leaderboardPrimary", alia
 $ const mrPrimary = emailX.getAdUnit({ name: "mrPrimary", alias: newsletter.alias });
 $ const mrSecondary = emailX.getAdUnit({ name: "mrSecondary", alias: newsletter.alias });
 
-$ const titleStyle = "font: bold 20px/30px 'Helvetica Neue', Helvetica, sans-serif; margin: 0;";
+$ const titleStyle = "font: bold 20px/30px 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 5px 10px;";
 $ const titleTableStyle = titleStyle + "table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; color: #fff; background-color: #00427B;";
 $ const featuredMainTableStyle = "background-color: #ebebeb";
 $ const contentLinkStyle = {


### PR DESCRIPTION
Extra comma was breaking the defaultValue, plus it needed to be included in the two that had the style overrides (FCN’s Weekly Update & PMs Weekly Update)

https://www.pivotaltracker.com/story/show/174177880

![Screen Shot 2020-08-04 at 2 15 29 PM](https://user-images.githubusercontent.com/12496550/89335163-466be480-d65d-11ea-95f4-d89b2b663b91.png)
![Screen Shot 2020-08-04 at 2 14 31 PM](https://user-images.githubusercontent.com/12496550/89335165-479d1180-d65d-11ea-9997-313e28d48e52.png)
