### PR TITLE
Removed font styles on `<td>`

### DIFF
--- a/packages/common/components/style-a/blocks/leaderboard-primary.marko
+++ b/packages/common/components/style-a/blocks/leaderboard-primary.marko
@@ -2,7 +2,7 @@ $ const { name, date } = input;
 
 <common-table width="700" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
   <tr>
-    <td style="font: 700 11px/16px Helvetica, Arial, sans-serif; border-collapse: separate; padding: 0 15px 15px 15px; min-width: 100%; text-align: center;">
+    <td style="padding: 0 15px 15px 15px; min-width: 100%;">
       <h3 style="font: 700 11px/16px Helvetica, Arial, sans-serif;margin: 5px; color: #999; text-align: left;">
         Advertisement
       </h3>


### PR DESCRIPTION
They’re already applied to the `<h3>` tag, they don’t need to be on the `<td>` as well.  Removing to fix an issue in Outlook.

After fix:
![Screen Shot 2020-08-05 at 2 43 58 PM](https://user-images.githubusercontent.com/12496550/89456927-3837ca00-d72a-11ea-9a20-4a04a7607afa.png)

Before fix:
![Screen Shot 2020-08-05 at 2 42 11 PM](https://user-images.githubusercontent.com/12496550/89456948-3b32ba80-d72a-11ea-81a2-e075d9fbc7ed.png)
