### PR TITLE
Add new alphaThemeConfigs graphql fragment

### DIFF
--- a/packages/common/components/style-b/blocks/footer-nav.marko
+++ b/packages/common/components/style-b/blocks/footer-nav.marko
@@ -1,8 +1,12 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
+import emailConfigurationFragment from "@endeavor-business-media/common/graphql/fragments/email-configuration";
 
 $ const footerStyle = defaultValue(input.footerStyle, "background-color: #000;");
 
-<common-table width="700" align="center" class="main footer-nav" style=`${footerStyle}` padding=10 spacing=0 >
+<!-- using temporarily for testing -->
+<h1>${input.footerColor}</h1>
+
+<common-table width="700" align="center" class="main footer-nav" padding=10 spacing=0 >
   <tr>
     <td>
       <common-style-b-brand-nav-element />

--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -4,6 +4,7 @@
   },
   "<common-style-b-footer-nav-block>": {
     "template": "./footer-nav.marko",
+    "@footer-color" : "string",
     "@footer-style" : "string"
   },
   "<common-style-b-simple-card-block>": {

--- a/packages/common/graphql/fragments/email-configuration.js
+++ b/packages/common/graphql/fragments/email-configuration.js
@@ -1,0 +1,44 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment EmailConfigurationFragment on EmailNewsletter {
+  id
+  name
+  alphaThemeConfigs {
+    edges {
+      node {
+        id
+        status
+        accentFontColor
+        headerLink
+        socialIcons
+        facebook
+        linkedin
+        twitter
+        youtube
+        instagram
+        pinterest
+        headerBgColor
+        headerTextColor
+        headerTemplate
+        dateToggle
+        footerColor
+        footerTextColor
+        manageSubscriptions
+        contactUs
+        advertise
+        headerLeft {
+          id
+          src
+        }
+        headerRight {
+          id
+          src
+        }
+      }
+    }
+  }
+}
+
+`;

--- a/tenants/evaluationengineering/templates/evaluation-test-news.marko
+++ b/tenants/evaluationengineering/templates/evaluation-test-news.marko
@@ -1,3 +1,4 @@
+import emailConfigurationFragment from "@endeavor-business-media/common/graphql/fragments/email-configuration";
 $ const { newsletter, date } = data;
 
 $ const contentLinkStyle = {
@@ -48,11 +49,10 @@ $ const buttonTextStyle = {
             section-id=64827
             date=date
             newsletter=newsletter
+            button=false
+            title=false
             img-width="200px"
             alignment="center"
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
           />
 
           <!-- #02 - Featured -->
@@ -96,6 +96,7 @@ $ const buttonTextStyle = {
 
           <common-style-b-footer-nav-block
             footer-style=footerStyle
+            footer-color=newsletter.footerColor
           />
 
           <common-style-b-opt-out-block />


### PR DESCRIPTION
Using footer-nav and evaluation-test-news as a playground for testing, obviously those will be changed once I can figure out how to correctly call the new fields.