### PR TITLE
Removed button and title from Evaluation Test News

### DIFF
--- a/tenants/evaluationengineering/templates/evaluation-test-news.marko
+++ b/tenants/evaluationengineering/templates/evaluation-test-news.marko
@@ -48,11 +48,10 @@ $ const buttonTextStyle = {
             section-id=64827
             date=date
             newsletter=newsletter
+            button=false
+            title=false
             img-width="200px"
             alignment="center"
-            content-link-style=contentLinkStyle
-            button-style=buttonStyle
-            button-text-style=buttonTextStyle
           />
 
           <!-- #02 - Featured -->


### PR DESCRIPTION
Should be:
![Screen Shot 2020-09-14 at 11 16 47 AM](https://user-images.githubusercontent.com/12496550/93111196-e6b12200-f67b-11ea-9150-2e8b2daba580.png)

Instead of:
![Screen Shot 2020-09-14 at 11 17 02 AM](https://user-images.githubusercontent.com/12496550/93111233-f03a8a00-f67b-11ea-8f49-9bdec6a3c351.png)
