### PR TITLE
Updates to TD's "Energizing" eNL (Release requested 10/01 or 10/02)

### DIFF
--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -691,7 +691,8 @@
     "@button-style": "string",
     "@button-text-style": "object",
     "@main-table-style": "string",
-    "@content-link-style": "object"
+    "@content-link-style": "object",
+    "@field": "string"
   },
   "<common-style-a-leaderboard-block>": {
     "template": "./leaderboard.marko",
@@ -799,7 +800,8 @@
     "@content-link-style": "object",
     "@teaser-style": "object",
     "@button-style": "string",
-    "@button-text-style": "object"
+    "@button-text-style": "object",
+    "@field": "string"
   },
   "<common-style-a-leaderboard-primary-block>": {
     "template": "./leaderboard-primary.marko",

--- a/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
@@ -8,7 +8,8 @@ $ const {
   teaserStyle,
   contentLinkStyle,
   buttonStyle,
-  buttonTextStyle
+  buttonTextStyle,
+  field
 } = input;
 
 $ const teaserWrapperStyle = {...teaserStyle, ...{lineHeight: "175%",msoLineHeightRule: "exactly", msoLineHeightAlt: "146%"}};
@@ -51,7 +52,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
           </tr>
           <tr>
             <td style=teaserWrapperStyle >
-              <common-content-teaser-element field="body" node=node teaser-style=teaserStyle tag="p" />
+              <common-content-teaser-element field=field node=node teaser-style=teaserStyle tag="p" />
             </td>
           </tr>
           <if(node.linkText)>
@@ -79,7 +80,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
     </tr>
     <tr>
       <td style=teaserWrapperStyle style="padding: 0 20px;" >
-        <common-content-teaser-element field="body" node=node teaser-style=teaserStyle tag="p" />
+        <common-content-teaser-element field=field node=node teaser-style=teaserStyle tag="p" />
       </td>
     </tr>
     <if(node.linkText)>

--- a/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
@@ -51,7 +51,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
           </tr>
           <tr>
             <td style=teaserWrapperStyle >
-              <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+              <common-content-teaser-element field="body" node=node teaser-style=teaserStyle tag="p" />
             </td>
           </tr>
           <if(node.linkText)>
@@ -79,7 +79,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
     </tr>
     <tr>
       <td style=teaserWrapperStyle style="padding: 0 20px;" >
-        <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+        <common-content-teaser-element field="body" node=node teaser-style=teaserStyle tag="p" />
       </td>
     </tr>
     <if(node.linkText)>

--- a/packages/common/components/style-a/blocks/special-edition-full-wrapper.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-wrapper.marko
@@ -13,7 +13,8 @@ $ const {
   buttonStyle,
   buttonTextStyle,
   showButton,
-  teaserStyle
+  teaserStyle,
+  field
 } = input;
 $ const titleTableStyle = defaultValue(input.titleTableStyle, "font: 400 13px/21px Garamond, serif; margin: 0; table-layout: fixed; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100% !important; color: ##C73E31; background-color: #ffffff; border-top: 4px solid ##C73E31;");
 $ const titleStyle = defaultValue(input.titleStyle, "font:700 15px/23px Arial, 'Helvetica Neue', Helvetica, sans-serif; margin-top: 9px; margin-left: 20px; margin-bottom: 9px;");
@@ -59,6 +60,7 @@ $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
                     button-style=buttonStyle
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
+                    field=field
                   />
                 </if>
                 <else>

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -54,6 +54,7 @@ $ const teaserStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      field="body"
     />
 
     <common-section-spacer-element />
@@ -69,6 +70,7 @@ $ const teaserStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      field="body"
     />
 
     <common-section-spacer-element />
@@ -100,6 +102,7 @@ $ const teaserStyle = {
       content-link-style=contentLinkStyle
       button-style=buttonStyle
       button-text-style=buttonTextStyle
+      field="body"
     />
 
     <common-section-spacer-element />

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -58,7 +58,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-special-edition-full-wrapper-block
       section-id=81737
       title="Brought to you by"
       date=date

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -43,10 +43,24 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-featured-section-wrapper-block
+    <common-style-a-special-edition-full-wrapper-block
       section-id=74425
-      title="Top Story"
-      limit=1
+      title="In The Spotlight"
+      date=date
+      newsletter=newsletter
+      title-table-style=titleTableStyle
+      title-style=titleStyle
+      main-table-style=mainTableStyle
+      content-link-style=contentLinkStyle
+      button-style=buttonStyle
+      button-text-style=buttonTextStyle
+    />
+
+    <common-section-spacer-element />
+
+    <common-style-a-card-section-wrapper-block
+      section-id=81737
+      title="Brought to you by"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -75,31 +89,9 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-leaderboard-primary-block
-      name=leaderboardPrimary
-      date=date
-    />
-
-    <common-section-spacer-element />
-
-    <common-style-a-card-section-wrapper-block
+    <common-style-a-special-edition-full-wrapper-block
       section-id=71093
-      title="News Flash"
-      date=date
-      newsletter=newsletter
-      title-table-style=titleTableStyle
-      title-style=titleStyle
-      main-table-style=mainTableStyle
-      content-link-style=contentLinkStyle
-      button-style=buttonStyle
-      button-text-style=buttonTextStyle
-    />
-
-    <common-section-spacer-element />
-
-    <common-style-a-card-section-wrapper-block
-      section-id=71094
-      title="Strategic Insights"
+      title="Top Stories"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle
@@ -114,7 +106,7 @@ $ const teaserStyle = {
 
     <common-style-a-list-section-wrapper-block
       section-id=71095
-      title="Trending on T&D World"
+      title="Trending"
       date=date
       newsletter=newsletter
       title-table-style=titleTableStyle


### PR DESCRIPTION
** Released requested on 10/01 or 10/02 **

Edit: Forgot to include the original request link: https://southcomm.atlassian.net/browse/DEV-192

- Update the name of the newsletter template from "Energizing" to "Energizing Today" 
- Update the "Top Story" section name to be "In The Spotlight" 
- Convert "In The Spotlight" to a 2 column format (i.e. the image on the left, the title/synopsis on the right, and the "FULL ARTICLE" button center-aligned on it's own line below...just like how the "Editor's Note" section on Industry Week's daily template is setup)
- Update the "Trending on T& D World" section header title to just "Trending" 
- Add new a section header named "Brought to you by" directly below the In the Spotlight section, if possible (this section header will be tied to the ad spot below...the TD World folks wanted to make it crystal-clear to the user that an ad block is below this section header)
- Remove the "Strategic Insights" section
- Update the "News Flash" section header title to be "Top Stories" and update the format of that section so it mirrors the setup of the "Top Stories" section on the Industry Week daily template (i.e. the 300px wide image on the left, the title/synopsis on the right, and the "FULL ARTICLE" button center-aligned on it's own line below).
- Remove leaderboard ad


![energizing-9-23](https://user-images.githubusercontent.com/6343242/94168933-2b973e80-fe5c-11ea-85e5-7b5b06120e31.png)
![energizing-9-22](https://user-images.githubusercontent.com/6343242/94168953-2fc35c00-fe5c-11ea-8232-f741349a19ed.png)
