### PR TITLE
Append DPM comments to content/promotion body links

### DIFF
--- a/packages/common/components/elements/content-teaser.marko
+++ b/packages/common/components/elements/content-teaser.marko
@@ -1,11 +1,19 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
+import appendDPMComments from "../../utils/dpm/append-to-links";
 
-$ const { node, tag, field } = input;
+$ const { tag, field } = input;
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "color": "#000000",
   "font": "400 14px/18px sans-serif",
   "margin": "0",
   "padding": "0"
+});
+
+$ const node = appendDPMComments({
+  fieldsToProcess: ["body"],
+  currentField: field,
+  node: input.node,
+  $global: out.global,
 });
 
 <marko-core-obj-text tag=tag obj=node field=field html=true attrs={ style: teaserStyle } />

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,7 @@
     "@base-cms/marko-newsletters-omail": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",
     "graphql": "^14.5.4",
-    "graphql-tag": "^2.10.1"
+    "graphql-tag": "^2.10.1",
+    "validator": "^13.1.17"
   }
 }

--- a/packages/common/utils/dpm/append-to-links.js
+++ b/packages/common/utils/dpm/append-to-links.js
@@ -1,0 +1,36 @@
+const DPMContentComponent = require('../../components/dpm/content');
+const extractUrls = require('../extract-urls');
+
+/**
+ *
+ * @param {object} params
+ * @param {string[]} fieldsToProcess Acceptable field keys to do processing on
+ * @param {string} currentField The current field to process
+ * @param {object} node The content object node
+ * @param {object} $global The Marko global object - needed for rendering the DPM comment string
+ */
+module.exports = ({
+  fieldsToProcess = [],
+  currentField,
+  node,
+  $global,
+} = {}) => {
+  // do not process if the current field is not marked for processing.
+  if (!fieldsToProcess.includes(currentField)) return node;
+
+  // retrieve the field value from the node.
+  let value = node[currentField];
+  // extract all <a> elements from the value.
+  const urls = extractUrls(value);
+  // render the DPM comment
+  const dpm = DPMContentComponent.renderToString({ node, $global });
+  // if no comments could be rendered, return the node as-is.
+  if (!dpm) return node;
+  // otherwise, insert the dpm comment right after the link.
+  urls.forEach((url) => {
+    const { element } = url;
+    value = value.replace(element, `${element}${dpm}`);
+  });
+  // update the node value with the injected comments
+  return { ...node, [currentField]: value };
+};

--- a/packages/common/utils/extract-urls.js
+++ b/packages/common/utils/extract-urls.js
@@ -1,0 +1,22 @@
+const { isURL } = require('validator');
+
+const matchPattern = new RegExp('(<a[^>]+href=[\'"])(\\s{0,}http.*?)(["\'][^>]*>.*?</a>)', 'igs');
+
+module.exports = (html) => {
+  const urls = [];
+  let match;
+  do {
+    match = matchPattern.exec(html);
+    if (match) {
+      // the url validator will fail if any spaces, <, or > characters are found.
+      const temp = match[2].trim()
+        .replace(/\s/g, '%20')
+        .replace(/</g, '%3C')
+        .replace(/>/g, '%3E');
+      if (isURL(temp, { protocols: ['http', 'https'], require_protocol: true })) {
+        urls.push({ value: match[2], element: match[0] });
+      }
+    }
+  } while (match);
+  return urls;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7404,6 +7404,11 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
+validator@^13.1.17:
+  version "13.1.17"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.17.tgz#ad677736950adddd3c37209484a6b2e0966579ad"
+  integrity sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg==
+
 value-or-function@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"


### PR DESCRIPTION
Allows for inline processing of links within content fields (bodies) and appends DPM comments when applicable (and enabled). Example: a promotion may have links within the body that's displayed in the newsletter. These links will now contain the appropriate DPM comments.

This functionality was added to the common teaser element (as this component is actually re-used for content bodies). If this functionality is required elsewhere, the `appendDPMComments` utility will need to be applied to those components as well.