### PR TITLE
Add newsletterQueryFragment to remaining tenants

### DIFF
--- a/tenants/americanmachinist/index.js
+++ b/tenants/americanmachinist/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/asumag/index.js
+++ b/tenants/asumag/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/bulktransporter/index.js
+++ b/tenants/bulktransporter/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/contractingbusiness/index.js
+++ b/tenants/contractingbusiness/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/contractormag/index.js
+++ b/tenants/contractormag/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/ecmweb/index.js
+++ b/tenants/ecmweb/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/ehstoday/index.js
+++ b/tenants/ehstoday/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/electricalmarketing/index.js
+++ b/tenants/electricalmarketing/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/electronicdesign/index.js
+++ b/tenants/electronicdesign/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/ewweb/index.js
+++ b/tenants/ewweb/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/fleetowner/index.js
+++ b/tenants/fleetowner/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/forgingmagazine/index.js
+++ b/tenants/forgingmagazine/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/foundrymag/index.js
+++ b/tenants/foundrymag/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/hpac/index.js
+++ b/tenants/hpac/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/hydraulicspneumatics/index.js
+++ b/tenants/hydraulicspneumatics/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/industryweek/index.js
+++ b/tenants/industryweek/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/machinedesign/index.js
+++ b/tenants/machinedesign/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/mhlnews/index.js
+++ b/tenants/mhlnews/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/mwrf/index.js
+++ b/tenants/mwrf/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/newequipment/index.js
+++ b/tenants/newequipment/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/powerelectronics/index.js
+++ b/tenants/powerelectronics/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/rdhmag/index.js
+++ b/tenants/rdhmag/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/refrigeratedtransporter/index.js
+++ b/tenants/refrigeratedtransporter/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/rermag/index.js
+++ b/tenants/rermag/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/sourcetoday/index.js
+++ b/tenants/sourcetoday/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/tdworld/index.js
+++ b/tenants/tdworld/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/trailerbodybuilders/index.js
+++ b/tenants/trailerbodybuilders/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/trucker/index.js
+++ b/tenants/trucker/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));

--- a/tenants/vspc/index.js
+++ b/tenants/vspc/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-newsletters');
+const newsletterQueryFragment = require('@endeavor-business-media/common/graphql/fragments/email-configuration');
 const coreConfig = require('./config/core');
 const customConfig = require('./config/custom');
 
@@ -10,6 +11,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch(e => setImmediate(() => { throw e; }));


### PR DESCRIPTION
Relates to: https://github.com/base-cms-newsletters/endeavor-business-media/pull/226

Adds the newsletterQueryFragment to remaning “style-a” tenants