### PR TITLE
Integrate alphaThemeConfigs for "style-a" components

### DIFF
--- a/packages/common/components/style-a/blocks/header.marko
+++ b/packages/common/components/style-a/blocks/header.marko
@@ -10,12 +10,15 @@ $ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
 $ const config = alphaThemeConfigs[0] ? getAsObject(alphaThemeConfigs[0], 'node') : null;
 $ const bgColor = config.headerBgColor ? config.headerBgColor : '#ffffff';
 $ const fontColor = config.headerBgColor ? config.headerTextColor : '#000000';
+$ const dateColor = bgColor.includes('#fff') ? '#000000' : fontColor;
+$ const descriptionColor = bgColor.includes('#fff') ? '#8c9190' : fontColor;
+
 $ const headerLink = config.headerLink ? config.headerLink : `https://${newsletter.site.host}`;
 
 <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
   <tr>
     <td height="75" width="60" valign="top" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; border-top: 2px solid #000000; border-bottom: 2px solid #000000; vertical-align: middle;">
-      <div style=`font-size: 12px; color: ${fontColor}; text-transform:uppercase; font-weight: normal; margin: 0 0 0 15px; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-align: center; white-space: nowrap;`>
+      <div style=`font-size: 12px; color: ${dateColor}; text-transform:uppercase; font-weight: normal; margin: 0 0 0 15px; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-align: center; white-space: nowrap;`>
         <span style="font-size: 18px;">
           ${date.format("MMM")}
         </span><br>
@@ -29,7 +32,7 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
         <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
           ${newsletter.name}
         </h1>
-        <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
+        <p style=`color: ${descriptionColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
           $!{newsletter.description}
         </p>
       </td>
@@ -57,7 +60,7 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
         <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
           ${newsletter.name}
         </h1>
-        <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
+        <p style=`color: ${descriptionColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
           $!{newsletter.description}
         </p>
       </td>

--- a/packages/common/components/style-a/blocks/header.marko
+++ b/packages/common/components/style-a/blocks/header.marko
@@ -14,7 +14,7 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
 
 <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
   <tr>
-    <td height="75" valign="top" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; min-width: 55px; border-top: 2px solid #000000; border-bottom: 2px solid #000000; vertical-align: middle;">
+    <td height="75" width="60" valign="top" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; border-top: 2px solid #000000; border-bottom: 2px solid #000000; vertical-align: middle;">
       <div style=`font-size: 12px; color: ${fontColor}; text-transform:uppercase; font-weight: normal; margin: 0 0 0 15px; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-align: center; white-space: nowrap;`>
         <span style="font-size: 18px;">
           ${date.format("MMM")}
@@ -24,15 +24,15 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
         </span>
       </div>
     </td>
-    <td height="75" valign="center" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #000000; border-bottom: 2px solid #000000; margin-right: 10px;">
-      <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
-        ${newsletter.name}
-      </h1>
-      <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
-        $!{newsletter.description}
-      </p>
-    </td>
     <if(config && config.headerLeft)>
+      <td height="75" valign="center" width="490" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; text-align: left; border-top: 2px solid #000000; border-bottom: 2px solid #000000; margin-right: 10px;">
+        <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
+          ${newsletter.name}
+        </h1>
+        <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
+          $!{newsletter.description}
+        </p>
+      </td>
       <td height="75" valign="top" bgcolor="#ffffff" width="5">
         &nbsp;
       </td>
@@ -53,7 +53,15 @@ $ const headerLink = config.headerLink ? config.headerLink : `https://${newslett
       </td>
     </if>
     <else>
-      <td height="75" width="105" bgcolor=bgColor style="border-top: 2px solid #000000; border-bottom: 2px solid #000000;">
+      <td height="75" valign="center" bgColor=bgColor width="590" style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; text-align: left; border-top: 2px solid #000000; border-bottom: 2px solid #000000; margin-right: 10px;">
+        <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
+          ${newsletter.name}
+        </h1>
+        <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
+          $!{newsletter.description}
+        </p>
+      </td>
+      <td height="75" width="50" bgcolor=bgColor style="border-top: 2px solid #000000; border-bottom: 2px solid #000000;">
         &nbsp;
       </td>
     </else>

--- a/packages/common/components/style-a/blocks/header.marko
+++ b/packages/common/components/style-a/blocks/header.marko
@@ -1,0 +1,61 @@
+import { getAsArray, getAsObject } from "@base-cms/object-path";
+
+$ const {
+  newsletter,
+  date,
+  imagePath
+} = input;
+
+$ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
+$ const config = alphaThemeConfigs[0] ? getAsObject(alphaThemeConfigs[0], 'node') : null;
+$ const bgColor = config.headerBgColor ? config.headerBgColor : '#ffffff';
+$ const fontColor = config.headerBgColor ? config.headerTextColor : '#000000';
+$ const headerLink = config.headerLink ? config.headerLink : `https://${newsletter.site.host}`;
+
+<common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+  <tr>
+    <td height="75" valign="top" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; min-width: 55px; border-top: 2px solid #000000; border-bottom: 2px solid #000000; vertical-align: middle;">
+      <div style=`font-size: 12px; color: ${fontColor}; text-transform:uppercase; font-weight: normal; margin: 0 0 0 15px; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; text-align: center; white-space: nowrap;`>
+        <span style="font-size: 18px;">
+          ${date.format("MMM")}
+        </span><br>
+        <span style="font-size:30px; ">
+          ${date.format("D")}
+        </span>
+      </div>
+    </td>
+    <td height="75" valign="center" bgColor=bgColor style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; text-align: left; width: 460px; border-top: 2px solid #000000; border-bottom: 2px solid #000000; margin-right: 10px;">
+      <h1 style=`color: ${fontColor}; font-size: 26px; margin: 5px 0 5px 15px; padding-right: 3px; text-transform: none; font-weight: bold; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;`>
+        ${newsletter.name}
+      </h1>
+      <p style=`color: ${fontColor}; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: -2px 0 0 15px; font-weight: 300;`>
+        $!{newsletter.description}
+      </p>
+    </td>
+    <if(config && config.headerLeft)>
+      <td height="75" valign="top" bgcolor="#ffffff" width="5">
+        &nbsp;
+      </td>
+      <td height="75" valign="center" width="140" align="center" style="font-family: Garamond, serif; font-size: 13px; border-collapse: separate; background-color: #ffffff; margin-left: 10px; border-top: 2px solid #bbb; border-bottom: 2px solid #bbb;">
+        <marko-newsletter-imgix
+          src=config.headerLeft.src
+          alt=newsletter.name
+          options={ w: 120 }
+          attrs={ border: 0, width: 120 }
+        >
+          <@link href=headerLink title=newsletter.name target="_blank" />
+        </marko-newsletter-imgix>
+      </td>
+      <td height="75" valign="top" bgcolor="#ffffff" width="5">
+        &nbsp;
+      </td>
+      <td height="75" valign="top" width="20" bgcolor=bgColor style="border-top: 2px solid #000000; border-bottom: 2px solid #000000;">
+      </td>
+    </if>
+    <else>
+      <td height="75" width="105" bgcolor=bgColor style="border-top: 2px solid #000000; border-bottom: 2px solid #000000;">
+        &nbsp;
+      </td>
+    </else>
+  </tr>
+</common-table>

--- a/packages/common/components/style-a/blocks/marko.json
+++ b/packages/common/components/style-a/blocks/marko.json
@@ -1,6 +1,7 @@
 {
   "<common-style-a-opt-out-block>": {
-    "template": "./opt-out.marko"
+    "template": "./opt-out.marko",
+    "@newsletter": "object"
   },
   "<common-style-a-featured-section-wrapper-block>": {
     "template": "./featured-section-wrapper.marko",
@@ -805,5 +806,17 @@
     "template": "./leaderboard-primary.marko",
     "@name": "string",
     "@date": "date"
+  },
+  "<common-style-a-header-block>": {
+    "template": "./header.marko",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@image-path": "string"
   }
 }

--- a/packages/common/components/style-a/blocks/opt-out.marko
+++ b/packages/common/components/style-a/blocks/opt-out.marko
@@ -1,29 +1,23 @@
-import { getAsArray } from "@base-cms/object-path";
-import { asObject } from "@base-cms/utils";
+import { getAsArray, getAsObject } from "@base-cms/object-path";
 
+$ const { newsletter } = data;
 $ const { website, config } = out.global;
-$ const socialMediaProviders = config.getAsArray('socialMediaLinks');
 
+$ const socialMediaProviders = config.getAsArray('socialMediaLinks');
+$ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
+$ const newsletterConfig = alphaThemeConfigs[0] ? getAsObject(alphaThemeConfigs[0], 'node') : null;
 
 <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0 attrs={ style: { "background-color": "#e5e5e5" } } >
-  <tr>
-    <td style="background-color: #e5e5e5; text-align: center;">
-      <p class="connect_info" style="margin: 10px; padding: 0; color: #000000; -webkit-margin-after: 10px; -webkit-margin-before: 10px; -webkit-margin-end: 10px; -webkit-margin-start: 10px; font: 700 14px/21px Helvetica, 'Helvetica Neue', Arial, sans-serif;">Connect With Us</p>
-      <div>
-        <for|socialLinks| of=socialMediaProviders>
-          <marko-newsletter-imgix
-            src=`/files/base/newsletter/connect/${socialLinks.provider}.png`
-            alt="social icon"
-            options={ w: 39 }
-            attrs={ border: 0, width: 39 }
-          >
-            <@link href=socialLinks.href title=socialLinks.title target="_blank" />
-          </marko-newsletter-imgix>
-          &nbsp;&nbsp;
-        </for>
-      </div>
-    </td>
-  </tr>
+  <if(newsletterConfig && newsletterConfig.socialIcons != 'none')>
+    <tr>
+      <td style="background-color: #e5e5e5; text-align: center;">
+        <p class="connect_info" style="margin: 10px; padding: 0; color: #000000; -webkit-margin-after: 10px; -webkit-margin-before: 10px; -webkit-margin-end: 10px; -webkit-margin-start: 10px; font: 700 14px/21px Helvetica, 'Helvetica Neue', Arial, sans-serif;">Connect With Us</p>
+        <div>
+          <common-social-icons-element newsletter=newsletter/>
+        </div>
+      </td>
+    </tr>
+  </if>
   <tr>
     <td style="background-color: #e5e5e5; padding: 10px; text-align: center; font: 400 10px/17px Arial, Helvetica, sans-serif;">
       <p style="margin:0px;margin-bottom:1em;">This email is being sent to
@@ -33,18 +27,30 @@ $ const socialMediaProviders = config.getAsArray('socialMediaLinks');
         Please add ${config.get("optOut.safeSenders")} to your address book or safe sender list to receive our emails in your inbox.
       </p>
       <p style="margin:0px;margin-bottom:1em;">
-        <a style="text-decoration: underline !important;" href="@{confirmunsubscribelink}@">Unsubscribe</a>
-        | <a style="text-decoration: underline !important;" href=`${config.get("optOut.manageSubscriptions")}`>Manage Newsletter Subscriptions</a>
-        | <a style="text-decoration: underline !important;" href="@{forwardtoafriendlink}@">Forward to a Friend</a>
-        | <a style="text-decoration: underline !important;" href=`${website.get("origin")}/contact-us`>Customer Service Center</a>
-        | <a style="text-decoration: underline !important;" href=`${config.get("optOut.privacyPolicyUrl")}`>Read Privacy Policy</a>
+        <a href="@{confirmunsubscribelink}@">Unsubscribe</a>
+        <if(newsletterConfig && newsletterConfig.manageSubscriptions)>
+          &nbsp;| <a href=newsletterConfig.manageSubscriptions>Manage Newsletter Subscriptions</a>
+        </if>
+        <else>
+          &nbsp;| <a href=`${config.get("optOut.manageSubscriptions")}`>Manage Newsletter Subscriptions</a>
+        </else>
+          &nbsp;| <a href="@{forwardtoafriendlink}@">Forward to a Friend</a>
+        <if(newsletterConfig && newsletterConfig.contactUs)>
+          &nbsp;| <a href=newsletterConfig.contactUs>Customer Service Center</a>
+        </if>
+        <else>
+          &nbsp;| <a href=`${website.get("origin")}/contact-us`>Customer Service Center</a>
+        </else>
+        | <a href=`${config.get("optOut.privacyPolicyUrl")}`>Read Privacy Policy</a>
         <if (config.get("optOut.findJobsUrl")) >
-        | <a style="text-decoration: underline !important;" href=`${config.get("optOut.findJobsUrl")}`>Find Jobs</a>
+        | <a href=`${config.get("optOut.findJobsUrl")}`>Find Jobs</a>
         </if>
       </p>
 
       <p style="margin:0px;margin-bottom:1em;">
-        If this email was forwarded to you and you are interested in subscribing, please <a style="text-decoration: underline !important;" href=`${config.get("optOut.signUp")}`>click here</a> to sign-up.
+        <if(newsletterConfig && newsletterConfig.subscribe)>
+          If this email was forwarded to you and you are interested in subscribing, please <a style="text-decoration: underline !important;" href=newsletterConfig.subscribe>click here</a> to sign-up.
+        </if>
       </p>
 
       <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/americanmachinist/config/core.js
+++ b/tenants/americanmachinist/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/AMMPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=AMMnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/AmericanMachnst',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/AmericanMachinist?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups?trk=anet_ug_grppro&gid=2880425&about=&elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/americanmachinist/templates/highlights.marko
+++ b/tenants/americanmachinist/templates/highlights.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -155,7 +156,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/americanmachinist/templates/imts-preview.marko
+++ b/tenants/americanmachinist/templates/imts-preview.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -146,7 +147,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/americanmachinist/templates/weekly-update.marko
+++ b/tenants/americanmachinist/templates/weekly-update.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -146,7 +147,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/asumag/config/core.js
+++ b/tenants/asumag/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/ASUPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=ASUnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/ASU_mag?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/asumag?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    // {
-    //   provider: 'linkedin',
-    //   href: '',
-    //   title: 'Follow us on LinkedIn',
-    // },
-  ],
 };

--- a/tenants/asumag/templates/facilities-focus.marko
+++ b/tenants/asumag/templates/facilities-focus.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-blue-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -115,7 +116,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/asumag/templates/first-monday-product-news.marko
+++ b/tenants/asumag/templates/first-monday-product-news.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-red-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -64,7 +65,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter />
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/asumag/templates/green-school-university.marko
+++ b/tenants/asumag/templates/green-school-university.marko
@@ -29,8 +29,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-red-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
 
     <common-section-spacer-element />
 
@@ -114,7 +116,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/asumag/templates/schoolhouse-beat.marko
+++ b/tenants/asumag/templates/schoolhouse-beat.marko
@@ -29,8 +29,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-red-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
 
     <common-section-spacer-element />
 
@@ -115,7 +117,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/bulktransporter/config/core.js
+++ b/tenants/bulktransporter/config/core.js
@@ -4,19 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/BKTPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=BKTnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/bulktransporter',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/bulktrans?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/bulktransporter/templates/bulk-logistics-trends.marko
+++ b/tenants/bulktransporter/templates/bulk-logistics-trends.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -123,7 +124,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/bulktransporter/templates/the-latest-issue.marko
+++ b/tenants/bulktransporter/templates/the-latest-issue.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -51,7 +52,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/config/core.js
+++ b/tenants/contractingbusiness/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/CBPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=CBnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/contractingbiz/?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/CBMag/?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/4078340/profile?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/contractingbusiness/templates/ahr-product-spotlight.marko
+++ b/tenants/contractingbusiness/templates/ahr-product-spotlight.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -63,7 +64,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/ahr-show-daily.marko
+++ b/tenants/contractingbusiness/templates/ahr-show-daily.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/cb-product-spotlight.marko
+++ b/tenants/contractingbusiness/templates/cb-product-spotlight.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -63,7 +64,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/contracting-business-success.marko
+++ b/tenants/contractingbusiness/templates/contracting-business-success.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -139,7 +140,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/hvac-talk.marko
+++ b/tenants/contractingbusiness/templates/hvac-talk.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/hvacr-distribution-business-product-spotlight.marko
+++ b/tenants/contractingbusiness/templates/hvacr-distribution-business-product-spotlight.marko
@@ -31,8 +31,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -51,7 +52,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/hvacr-hotmail.marko
+++ b/tenants/contractingbusiness/templates/hvacr-hotmail.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/hvacr-hydronics-distribution-bus.marko
+++ b/tenants/contractingbusiness/templates/hvacr-hydronics-distribution-bus.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <<common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractingbusiness/templates/refrigerant-4-1-1.marko
+++ b/tenants/contractingbusiness/templates/refrigerant-4-1-1.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractormag/config/core.js
+++ b/tenants/contractormag/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/CONTRPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=CONTRnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/contractormag?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/CONTRACTOR-Magazine-95416372437?ref=ts&elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/4078340?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/contractormag/templates/connected-contractor.marko
+++ b/tenants/contractormag/templates/connected-contractor.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -117,7 +118,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractormag/templates/contractor-newsletter.marko
+++ b/tenants/contractormag/templates/contractor-newsletter.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/contractormag/templates/product-spotlight.marko
+++ b/tenants/contractormag/templates/product-spotlight.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -63,7 +64,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/config/core.js
+++ b/tenants/ecmweb/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'enews.ecmweb.com and mail.ecmweb.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/ECMPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=ECMnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#1/ecmweb',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/pages/Electrical-Construction-Maintenance/46473364997?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups?home=&gid=2685562&trk=anet_ug_hm&elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/ecmweb/templates/code-watch.marko
+++ b/tenants/ecmweb/templates/code-watch.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/electrical-zone.marko
+++ b/tenants/ecmweb/templates/electrical-zone.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/etrain.marko
+++ b/tenants/ecmweb/templates/etrain.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/illumination-insider.marko
+++ b/tenants/ecmweb/templates/illumination-insider.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/lightfair-show-coverage.marko
+++ b/tenants/ecmweb/templates/lightfair-show-coverage.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/mro-insider.marko
+++ b/tenants/ecmweb/templates/mro-insider.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/neca-show-coverage.marko
+++ b/tenants/ecmweb/templates/neca-show-coverage.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/pq-news-beat.marko
+++ b/tenants/ecmweb/templates/pq-news-beat.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/product-news-wire.marko
+++ b/tenants/ecmweb/templates/product-news-wire.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -66,7 +67,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ecmweb/templates/safety-matters.marko
+++ b/tenants/ecmweb/templates/safety-matters.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ehstoday/config/core.js
+++ b/tenants/ehstoday/config/core.js
@@ -4,19 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/EHSPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=EHSnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/EHSToday',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/pages/EHS-Today/66542218626?ref=ts&elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/ehstoday/templates/construction-safety.marko
+++ b/tenants/ehstoday/templates/construction-safety.marko
@@ -34,8 +34,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -148,7 +149,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ehstoday/templates/management.marko
+++ b/tenants/ehstoday/templates/management.marko
@@ -34,8 +34,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -148,7 +149,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ehstoday/templates/safety-tech-analytics-news.marko
+++ b/tenants/ehstoday/templates/safety-tech-analytics-news.marko
@@ -34,8 +34,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -148,7 +149,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ehstoday/templates/weekly-update.marko
+++ b/tenants/ehstoday/templates/weekly-update.marko
@@ -34,8 +34,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,8 @@ $ const teaserStyle = {
     />
 
     <common-section-spacer-element />
-    <common-style-a-opt-out-block />
+
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electricalmarketing/templates/electrical-marketing-update.marko
+++ b/tenants/electricalmarketing/templates/electrical-marketing-update.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/config/core.js
+++ b/tenants/electronicdesign/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/EDZPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=EDZnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/ElectronicDesgn?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/ElectronicDesign?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/4210549/?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/electronicdesign/templates/analog-power-source.marko
+++ b/tenants/electronicdesign/templates/analog-power-source.marko
@@ -34,8 +34,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-    />
-    <tenant-header-block image-path="/files/base/ebm/electronicdesign/image/static/newsletter/analog_power_source_header.jpg" date=date newsletter=newsletter />
+      teaser=newsletter.teaser
+      />
+
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -82,7 +84,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/automotive-electronics.marko
+++ b/tenants/electronicdesign/templates/automotive-electronics.marko
@@ -34,8 +34,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-    />
-    <tenant-header-block image-path="/files/base/ebm/electronicdesign/image/static/newsletter/automotive_electronics_header.jpg" date=date newsletter=newsletter />
+      teaser=newsletter.teaser
+      />
+
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -82,7 +84,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/ed-update-power-and-analog.marko
+++ b/tenants/electronicdesign/templates/ed-update-power-and-analog.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-special-edition-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -655,7 +656,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/ed-update.marko
+++ b/tenants/electronicdesign/templates/ed-update.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-special-edition-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -655,7 +656,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/electronic-design-today.marko
+++ b/tenants/electronicdesign/templates/electronic-design-today.marko
@@ -34,8 +34,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-    />
-    <tenant-header-block image-path="/files/base/ebm/electronicdesign/image/static/newsletter/today_header.jpg" date=date newsletter=newsletter />
+      teaser=newsletter.teaser
+      />
+
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -82,7 +84,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/embedded-update.marko
+++ b/tenants/electronicdesign/templates/embedded-update.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-special-edition-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -655,7 +656,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/iot-for-engineers.marko
+++ b/tenants/electronicdesign/templates/iot-for-engineers.marko
@@ -34,8 +34,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-    />
-    <tenant-header-block image-path="/files/base/ebm/electronicdesign/image/static/newsletter/iot_for_engineers_header.jpg" date=date newsletter=newsletter />
+      teaser=newsletter.teaser
+      />
+
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -82,7 +84,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/electronicdesign/templates/product-spotlight.marko
+++ b/tenants/electronicdesign/templates/product-spotlight.marko
@@ -32,8 +32,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-    />
-    <tenant-header-block image-path="/files/base/ebm/electronicdesign/image/static/newsletter/product_spotlight_header.jpg" date=date newsletter=newsletter />
+      teaser=newsletter.teaser
+      />
+
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -50,7 +52,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ewweb/config/core.js
+++ b/tenants/ewweb/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/EWPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=EWnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/ElecWholesaling?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/ElectricalConstructionMaintenanceMagazine?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/2685562?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/ewweb/templates/gbiz.marko
+++ b/tenants/ewweb/templates/gbiz.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ewweb/templates/product-alert.marko
+++ b/tenants/ewweb/templates/product-alert.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -63,7 +64,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/ewweb/templates/update.marko
+++ b/tenants/ewweb/templates/update.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -114,7 +115,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/config/core.js
+++ b/tenants/fleetowner/config/core.js
@@ -12,19 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/FOWNPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=FOWNnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/fleetowner?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://facebook.com/fleetowner?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/fleetowner/templates/digital-edition.marko
+++ b/tenants/fleetowner/templates/digital-edition.marko
@@ -28,8 +28,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/digital_edition_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -47,7 +48,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/equipment-weekly.marko
+++ b/tenants/fleetowner/templates/equipment-weekly.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/equipment_weekly_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/fleet-owner-breaking-news.marko
+++ b/tenants/fleetowner/templates/fleet-owner-breaking-news.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/fo-breaking-news-enl.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/fleet-owner-newsline.marko
+++ b/tenants/fleetowner/templates/fleet-owner-newsline.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/fleet_owner_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
+++ b/tenants/fleetowner/templates/heavy-duty-pickup-van.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/commercial_work_trucks_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/info-tech.marko
+++ b/tenants/fleetowner/templates/info-tech.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/info_tech_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -147,7 +148,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/maintenance-matters.marko
+++ b/tenants/fleetowner/templates/maintenance-matters.marko
@@ -31,8 +31,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/maintenance_matters.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -70,7 +71,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-webinars-edition.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/resources_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -85,7 +86,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
+++ b/tenants/fleetowner/templates/on-demand-resources-whitepapers-edition.marko
@@ -45,8 +45,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/resources_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -85,7 +86,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/regulation-resource-center.marko
+++ b/tenants/fleetowner/templates/regulation-resource-center.marko
@@ -49,8 +49,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/regulation_resource_center_header.png" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -73,7 +74,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/fleetowner/templates/top-5.marko
+++ b/tenants/fleetowner/templates/top-5.marko
@@ -46,8 +46,9 @@ $ const featuredButtonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/fleetowner/image/static/newsletter/top-5.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 
@@ -112,7 +113,7 @@ $ const featuredButtonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/forgingmagazine/config/core.js
+++ b/tenants/forgingmagazine/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/FRGPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=FRGnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/forgingmag?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/ForgingMagazine?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups?home=&gid=2880425&trk=anet_ug_hm&elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/forgingmagazine/templates/e-newsletter.marko
+++ b/tenants/forgingmagazine/templates/e-newsletter.marko
@@ -145,7 +145,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/forgingmagazine/templates/e-newsletter.marko
+++ b/tenants/forgingmagazine/templates/e-newsletter.marko
@@ -31,8 +31,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/foundrymag/config/core.js
+++ b/tenants/foundrymag/config/core.js
@@ -4,14 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/FMTPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=FMTnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/foundrymag',
-      title: 'Follow us on Twitter',
-    },
-  ],
 };

--- a/tenants/foundrymag/templates/metalcasting-weekly.marko
+++ b/tenants/foundrymag/templates/metalcasting-weekly.marko
@@ -31,8 +31,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
 
     <common-section-spacer-element />
 

--- a/tenants/foundrymag/templates/metalcasting-weekly.marko
+++ b/tenants/foundrymag/templates/metalcasting-weekly.marko
@@ -145,7 +145,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hpac/config/core.js
+++ b/tenants/hpac/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/HPACPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=HPACnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/hpaceng?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/hpacengineering?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/7486557?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/hpac/templates/engineering-green-buildings.marko
+++ b/tenants/hpac/templates/engineering-green-buildings.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/hpac/templates/engineering-green-buildings.marko
+++ b/tenants/hpac/templates/engineering-green-buildings.marko
@@ -114,7 +114,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hpac/templates/fastrack.marko
+++ b/tenants/hpac/templates/fastrack.marko
@@ -29,8 +29,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
 
     <common-section-spacer-element />
 

--- a/tenants/hpac/templates/fastrack.marko
+++ b/tenants/hpac/templates/fastrack.marko
@@ -114,7 +114,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hpac/templates/product-spotlight.marko
+++ b/tenants/hpac/templates/product-spotlight.marko
@@ -63,7 +63,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hpac/templates/product-spotlight.marko
+++ b/tenants/hpac/templates/product-spotlight.marko
@@ -29,8 +29,10 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
+
 
     <common-section-spacer-element />
 

--- a/tenants/hydraulicspneumatics/config/core.js
+++ b/tenants/hydraulicspneumatics/config/core.js
@@ -4,24 +4,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/HYPNPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=HYPNnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://www.twitter.com/H_and_P_knows?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/HydraulicsPneumatics?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/company/11091630?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/hydraulicspneumatics/templates/fluid-power.marko
+++ b/tenants/hydraulicspneumatics/templates/fluid-power.marko
@@ -107,7 +107,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hydraulicspneumatics/templates/fluid-power.marko
+++ b/tenants/hydraulicspneumatics/templates/fluid-power.marko
@@ -58,8 +58,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block header-style="background-color: #034b8d; color: #fff;" image-path="/files/base/ebm/hydraulicspneumatics/image/static/newsletter/fluid_power_header.png" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/hydraulicspneumatics/templates/ifpe-show-daily.marko
+++ b/tenants/hydraulicspneumatics/templates/ifpe-show-daily.marko
@@ -57,8 +57,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block header-style="background-color: #034b8d; color: #fff;" image-path="/files/base/ebm/hydraulicspneumatics/image/static/newsletter/fluid_power_header.png" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/hydraulicspneumatics/templates/ifpe-show-daily.marko
+++ b/tenants/hydraulicspneumatics/templates/ifpe-show-daily.marko
@@ -106,7 +106,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/hydraulicspneumatics/templates/product-source.marko
+++ b/tenants/hydraulicspneumatics/templates/product-source.marko
@@ -59,8 +59,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block header-style="background-color: transparent; color: #fff;" image-path="/files/base/ebm/hydraulicspneumatics/image/static/newsletter/product_source_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/hydraulicspneumatics/templates/product-source.marko
+++ b/tenants/hydraulicspneumatics/templates/product-source.marko
@@ -79,7 +79,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/config/core.js
+++ b/tenants/industryweek/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/IDWPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=IDWnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'http://twitter.com/?elqTrack=true#!/IndustryWeek',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'http://www.facebook.com/pages/IndustryWeek/91310488418',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/147721/profile',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/industryweek/templates/continuous-improvements.marko
+++ b/tenants/industryweek/templates/continuous-improvements.marko
@@ -153,7 +153,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/continuous-improvements.marko
+++ b/tenants/industryweek/templates/continuous-improvements.marko
@@ -39,8 +39,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
@@ -172,7 +172,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-afternoon-edition.marko
@@ -58,8 +58,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-image-header-block image-path="/files/base/ebm/industryweek/image/static/newsletter/afternoon_edition_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/daily-headlines-morning-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-morning-edition.marko
@@ -172,7 +172,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/daily-headlines-morning-edition.marko
+++ b/tenants/industryweek/templates/daily-headlines-morning-edition.marko
@@ -58,8 +58,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-image-header-block image-path="/files/base/ebm/industryweek/image/static/newsletter/morning_edition_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/leadership-insights.marko
+++ b/tenants/industryweek/templates/leadership-insights.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/leadership-insights.marko
+++ b/tenants/industryweek/templates/leadership-insights.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/manufacturing-technology.marko
+++ b/tenants/industryweek/templates/manufacturing-technology.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/manufacturing-technology.marko
+++ b/tenants/industryweek/templates/manufacturing-technology.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/quick-manufacturing-news.marko
+++ b/tenants/industryweek/templates/quick-manufacturing-news.marko
@@ -39,8 +39,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-qmn-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/supply-chain-insights.marko
+++ b/tenants/industryweek/templates/supply-chain-insights.marko
@@ -38,8 +38,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/supply-chain-insights.marko
+++ b/tenants/industryweek/templates/supply-chain-insights.marko
@@ -152,7 +152,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/weekly-hotlist.marko
+++ b/tenants/industryweek/templates/weekly-hotlist.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/industryweek/templates/weekly-hotlist.marko
+++ b/tenants/industryweek/templates/weekly-hotlist.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/workforce-watch.marko
+++ b/tenants/industryweek/templates/workforce-watch.marko
@@ -149,7 +149,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/industryweek/templates/workforce-watch.marko
+++ b/tenants/industryweek/templates/workforce-watch.marko
@@ -35,8 +35,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/config/core.js
+++ b/tenants/machinedesign/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/MDZPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=MDZnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/MachineDesign?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/MachineDesignMagazine?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/company/10998894?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/machinedesign/templates/3d-printing-cad.marko
+++ b/tenants/machinedesign/templates/3d-printing-cad.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/3d_printing_cad_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/3d-printing-cad.marko
+++ b/tenants/machinedesign/templates/3d-printing-cad.marko
@@ -81,7 +81,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/daily.marko
+++ b/tenants/machinedesign/templates/daily.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/daily_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/daily.marko
+++ b/tenants/machinedesign/templates/daily.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/medical-design.marko
+++ b/tenants/machinedesign/templates/medical-design.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/medical_design_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/medical-design.marko
+++ b/tenants/machinedesign/templates/medical-design.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/motion.marko
+++ b/tenants/machinedesign/templates/motion.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/motion_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/motion.marko
+++ b/tenants/machinedesign/templates/motion.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/product-spotlight.marko
+++ b/tenants/machinedesign/templates/product-spotlight.marko
@@ -52,7 +52,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/product-spotlight.marko
+++ b/tenants/machinedesign/templates/product-spotlight.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/product_spotlight_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/robotics-automation.marko
+++ b/tenants/machinedesign/templates/robotics-automation.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/machinedesign/image/static/newsletter/robotics_automation_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/machinedesign/templates/robotics-automation.marko
+++ b/tenants/machinedesign/templates/robotics-automation.marko
@@ -80,7 +80,7 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/special-edition.marko
+++ b/tenants/machinedesign/templates/special-edition.marko
@@ -657,7 +657,7 @@ $ const isFull = false;
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/machinedesign/templates/special-edition.marko
+++ b/tenants/machinedesign/templates/special-edition.marko
@@ -36,8 +36,9 @@ $ const isFull = false;
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-special-edition-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mhlnews/config/core.js
+++ b/tenants/mhlnews/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/MHLPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=MHLnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/MHLeditor',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups?about=&gid=2003884&trk=anet_ug_grppro%20&elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/pages/Material-Handling-Logistics/141327922238?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/mhlnews/templates/newsmakers.marko
+++ b/tenants/mhlnews/templates/newsmakers.marko
@@ -37,8 +37,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mhlnews/templates/newsmakers.marko
+++ b/tenants/mhlnews/templates/newsmakers.marko
@@ -151,7 +151,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -38,8 +38,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mhlnews/templates/products-of-the-week.marko
+++ b/tenants/mhlnews/templates/products-of-the-week.marko
@@ -152,7 +152,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mwrf/config/core.js
+++ b/tenants/mwrf/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/MWRFPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=MWRFnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/MicrowavesRF?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'http://www.facebook.com/microwavesrf?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/organization/11001138?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/mwrf/templates/defense-electronics.marko
+++ b/tenants/mwrf/templates/defense-electronics.marko
@@ -33,8 +33,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/mwrf/image/static/newsletter/defense_electronics_header.png" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mwrf/templates/defense-electronics.marko
+++ b/tenants/mwrf/templates/defense-electronics.marko
@@ -83,7 +83,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mwrf/templates/mwrf-update.marko
+++ b/tenants/mwrf/templates/mwrf-update.marko
@@ -311,7 +311,7 @@ $ const isFull = false;
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mwrf/templates/mwrf-update.marko
+++ b/tenants/mwrf/templates/mwrf-update.marko
@@ -36,8 +36,9 @@ $ const isFull = false;
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-special-edition-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mwrf/templates/product-spotlight.marko
+++ b/tenants/mwrf/templates/product-spotlight.marko
@@ -79,7 +79,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/mwrf/templates/product-spotlight.marko
+++ b/tenants/mwrf/templates/product-spotlight.marko
@@ -59,8 +59,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/mwrf/image/static/newsletter/product_spotlight_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mwrf/templates/today.marko
+++ b/tenants/mwrf/templates/today.marko
@@ -33,8 +33,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/mwrf/image/static/newsletter/daily_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/mwrf/templates/today.marko
+++ b/tenants/mwrf/templates/today.marko
@@ -83,7 +83,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/config/core.js
+++ b/tenants/newequipment/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/NEDPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=NEDnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/newequipment',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/NewEquipment?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/grp/home?gid=4850947&elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/newequipment/templates/adhesive-lubricants-sealants-monthly.marko
+++ b/tenants/newequipment/templates/adhesive-lubricants-sealants-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/adhesive-lubricants-sealants-monthly.marko
+++ b/tenants/newequipment/templates/adhesive-lubricants-sealants-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/electrical-electronics-monthly.marko
+++ b/tenants/newequipment/templates/electrical-electronics-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/electrical-electronics-monthly.marko
+++ b/tenants/newequipment/templates/electrical-electronics-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/facilities-maintenance-plant-operation-monthly.marko
+++ b/tenants/newequipment/templates/facilities-maintenance-plant-operation-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/facilities-maintenance-plant-operation-monthly.marko
+++ b/tenants/newequipment/templates/facilities-maintenance-plant-operation-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/fluid-power-monthly.marko
+++ b/tenants/newequipment/templates/fluid-power-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/fluid-power-monthly.marko
+++ b/tenants/newequipment/templates/fluid-power-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/industry-insider.marko
+++ b/tenants/newequipment/templates/industry-insider.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/industry-insider.marko
+++ b/tenants/newequipment/templates/industry-insider.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/maintenance-operations.marko
+++ b/tenants/newequipment/templates/maintenance-operations.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/maintenance-operations.marko
+++ b/tenants/newequipment/templates/maintenance-operations.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/material-handling-packaging-monthly.marko
+++ b/tenants/newequipment/templates/material-handling-packaging-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/material-handling-packaging-monthly.marko
+++ b/tenants/newequipment/templates/material-handling-packaging-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/material-handling-robotics.marko
+++ b/tenants/newequipment/templates/material-handling-robotics.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/material-handling-robotics.marko
+++ b/tenants/newequipment/templates/material-handling-robotics.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/motion-control-monthly.marko
+++ b/tenants/newequipment/templates/motion-control-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/motion-control-monthly.marko
+++ b/tenants/newequipment/templates/motion-control-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/pipes-valves-and-fittings-monthly.marko
+++ b/tenants/newequipment/templates/pipes-valves-and-fittings-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/pipes-valves-and-fittings-monthly.marko
+++ b/tenants/newequipment/templates/pipes-valves-and-fittings-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/robotics-monthly.marko
+++ b/tenants/newequipment/templates/robotics-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/robotics-monthly.marko
+++ b/tenants/newequipment/templates/robotics-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/safety-security-monthly.marko
+++ b/tenants/newequipment/templates/safety-security-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/safety-security-monthly.marko
+++ b/tenants/newequipment/templates/safety-security-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/sensor-monthly.marko
+++ b/tenants/newequipment/templates/sensor-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/sensor-monthly.marko
+++ b/tenants/newequipment/templates/sensor-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/smart-manufacturing-iot.marko
+++ b/tenants/newequipment/templates/smart-manufacturing-iot.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/smart-manufacturing-iot.marko
+++ b/tenants/newequipment/templates/smart-manufacturing-iot.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/tools-monthly.marko
+++ b/tenants/newequipment/templates/tools-monthly.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/tools-monthly.marko
+++ b/tenants/newequipment/templates/tools-monthly.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/tools-ppe.marko
+++ b/tenants/newequipment/templates/tools-ppe.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/tools-ppe.marko
+++ b/tenants/newequipment/templates/tools-ppe.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/newequipment/templates/week-in-review.marko
+++ b/tenants/newequipment/templates/week-in-review.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/week-in-review.marko
+++ b/tenants/newequipment/templates/week-in-review.marko
@@ -146,7 +146,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/powerelectronics/config/core.js
+++ b/tenants/powerelectronics/config/core.js
@@ -12,19 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/PWEPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=PWEnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/PowerElecTech?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/powerelectronicstech?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/powerelectronics/templates/product-spotlight.marko
+++ b/tenants/powerelectronics/templates/product-spotlight.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/powerelectronics/image/static/newsletter/product_spotlight_header.png" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/powerelectronics/templates/product-spotlight.marko
+++ b/tenants/powerelectronics/templates/product-spotlight.marko
@@ -53,7 +53,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/refrigeratedtransporter/config/core.js
+++ b/tenants/refrigeratedtransporter/config/core.js
@@ -12,14 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/RFTPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=RFTnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/RefrigeratedTransporter?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/refrigeratedtransporter/templates/business-picture.marko
+++ b/tenants/refrigeratedtransporter/templates/business-picture.marko
@@ -166,7 +166,7 @@ $ const buttonTextStyle = {
     </common-table>
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/refrigeratedtransporter/templates/business-picture.marko
+++ b/tenants/refrigeratedtransporter/templates/business-picture.marko
@@ -35,8 +35,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
     <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>

--- a/tenants/rermag/config/core.js
+++ b/tenants/rermag/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/RERPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=RERnewpref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/RERmagazine?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/rentalequipmentregister?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/4078580?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-  ],
 };

--- a/tenants/rermag/templates/rer-product-wire.marko
+++ b/tenants/rermag/templates/rer-product-wire.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-red-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/rermag/templates/rer-product-wire.marko
+++ b/tenants/rermag/templates/rer-product-wire.marko
@@ -114,7 +114,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/rermag/templates/rer-reports-special-ara-show-edition.marko
+++ b/tenants/rermag/templates/rer-reports-special-ara-show-edition.marko
@@ -52,7 +52,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/rermag/templates/rer-reports-special-ara-show-edition.marko
+++ b/tenants/rermag/templates/rer-reports-special-ara-show-edition.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-blue-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/rermag/templates/rer-reports.marko
+++ b/tenants/rermag/templates/rer-reports.marko
@@ -29,8 +29,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-blue-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/rermag/templates/rer-reports.marko
+++ b/tenants/rermag/templates/rer-reports.marko
@@ -114,7 +114,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/sourcetoday/config/core.js
+++ b/tenants/sourcetoday/config/core.js
@@ -12,19 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/SRCTPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=SRCTnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/Source_Today?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/SourceTodayMagazine/43140773120?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/sourcetoday/templates/source-today.marko
+++ b/tenants/sourcetoday/templates/source-today.marko
@@ -44,8 +44,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/sourcetoday/image/static/newsletter/source_today_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/sourcetoday/templates/source-today.marko
+++ b/tenants/sourcetoday/templates/source-today.marko
@@ -95,7 +95,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/config/core.js
+++ b/tenants/tdworld/config/core.js
@@ -12,30 +12,6 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/TWPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=TWnewpref',
     findJobsUrl: 'https://jobs.tdworld.com/?pk=UMeNL',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/tdworldmag?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/pages/Transmission-Distribution-World/110964078942390?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    {
-      provider: 'linkedin',
-      href: 'https://www.linkedin.com/groups/Transmission-Distribution-World-4078692?elqTrack=true',
-      title: 'Follow us on LinkedIn',
-    },
-    {
-      provider: 'youtube',
-      href: 'https://www.youtube.com/channel/UCD6JFCCOwOPu2v-KBcww_qw?elqTrack=true',
-      title: 'Watch our videos on Youtube',
-    },
-  ],
 };

--- a/tenants/tdworld/templates/careers.marko
+++ b/tenants/tdworld/templates/careers.marko
@@ -133,7 +133,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/careers.marko
+++ b/tenants/tdworld/templates/careers.marko
@@ -38,8 +38,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -139,7 +139,7 @@ $ const teaserStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/energizing.marko
+++ b/tenants/tdworld/templates/energizing.marko
@@ -38,8 +38,9 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/europe-insights.marko
+++ b/tenants/tdworld/templates/europe-insights.marko
@@ -30,8 +30,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/europe-insights.marko
+++ b/tenants/tdworld/templates/europe-insights.marko
@@ -94,7 +94,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/grid-innovations.marko
+++ b/tenants/tdworld/templates/grid-innovations.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/grid-innovations.marko
+++ b/tenants/tdworld/templates/grid-innovations.marko
@@ -93,7 +93,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/ieee-pes-show-update.marko
+++ b/tenants/tdworld/templates/ieee-pes-show-update.marko
@@ -273,7 +273,7 @@ $ const buttonTextStyle = {
       </tr>
     </common-table>
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/ieee-pes-show-update.marko
+++ b/tenants/tdworld/templates/ieee-pes-show-update.marko
@@ -34,8 +34,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
 <!--- Leaderboard Primary Advertisement -->
     <common-style-a-leaderboard-primary-block

--- a/tenants/tdworld/templates/international-linemans-rodeo.marko
+++ b/tenants/tdworld/templates/international-linemans-rodeo.marko
@@ -165,7 +165,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/international-linemans-rodeo.marko
+++ b/tenants/tdworld/templates/international-linemans-rodeo.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/lineman-life.marko
+++ b/tenants/tdworld/templates/lineman-life.marko
@@ -111,7 +111,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/lineman-life.marko
+++ b/tenants/tdworld/templates/lineman-life.marko
@@ -30,8 +30,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/projects-in-progress.marko
+++ b/tenants/tdworld/templates/projects-in-progress.marko
@@ -33,8 +33,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/projects-in-progress.marko
+++ b/tenants/tdworld/templates/projects-in-progress.marko
@@ -130,7 +130,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/smart-utility.marko
+++ b/tenants/tdworld/templates/smart-utility.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/smart-utility.marko
+++ b/tenants/tdworld/templates/smart-utility.marko
@@ -105,7 +105,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/test-monitor-control.marko
+++ b/tenants/tdworld/templates/test-monitor-control.marko
@@ -33,8 +33,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-   <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/test-monitor-control.marko
+++ b/tenants/tdworld/templates/test-monitor-control.marko
@@ -106,7 +106,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/tdworld/templates/uai-analytics-insight.marko
+++ b/tenants/tdworld/templates/uai-analytics-insight.marko
@@ -50,10 +50,10 @@ $ const getReadMoreText = (node) => {
   </@head>
   <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
     <common-banner-element
-      name=newsletter.name
+      date=date
+      teaser=newsletter.teaser
     />
-
-    <tenant-header-full-image-block newsletter=newsletter header-href="https://utilityanalytics.com/" logo-path="/files/base/ebm/tdworld/image/static/newsletter/uai_header.jpg" />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/vegetation-management-insights.marko
+++ b/tenants/tdworld/templates/vegetation-management-insights.marko
@@ -32,9 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-
-    <tenant-header-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/tdworld/templates/vegetation-management-insights.marko
+++ b/tenants/tdworld/templates/vegetation-management-insights.marko
@@ -105,7 +105,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trailerbodybuilders/config/core.js
+++ b/tenants/trailerbodybuilders/config/core.js
@@ -12,24 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/TBBPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=TBBnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/?elqTrack=true#!/trailerbb',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/trailerbodybuilders?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-    // {
-    //   provider: 'linkedin',
-    //   href: '',
-    //   title: 'Follow us on LinkedIn',
-    // },
-  ],
 };

--- a/tenants/trailerbodybuilders/templates/buyers-express.marko
+++ b/tenants/trailerbodybuilders/templates/buyers-express.marko
@@ -68,7 +68,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trailerbodybuilders/templates/buyers-express.marko
+++ b/tenants/trailerbodybuilders/templates/buyers-express.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-gold-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/trailerbodybuilders/templates/market-watch.marko
+++ b/tenants/trailerbodybuilders/templates/market-watch.marko
@@ -36,8 +36,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-gold-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-table width="700" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>

--- a/tenants/trailerbodybuilders/templates/market-watch.marko
+++ b/tenants/trailerbodybuilders/templates/market-watch.marko
@@ -140,7 +140,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trailerbodybuilders/templates/the-latest-issue.marko
+++ b/tenants/trailerbodybuilders/templates/the-latest-issue.marko
@@ -51,7 +51,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trailerbodybuilders/templates/the-latest-issue.marko
+++ b/tenants/trailerbodybuilders/templates/the-latest-issue.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-gold-block date=date newsletter=newsletter />
+    <common-style-a-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/trucker/config/core.js
+++ b/tenants/trucker/config/core.js
@@ -12,19 +12,5 @@ module.exports = {
     safeSenders: 'news.endeavorb2b.com and mail.endeavorb2b.com',
     privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
     phoneNumber: '800-547-7377',
-    manageSubscriptions: 'https://endeavor.dragonforms.com/AMTKPrefPage?r=@{encrypted_customer_id}@&pk=NLFooter',
-    signUp: 'https://endeavor.dragonforms.com/loading.do?omedasite=AMTKnewPref',
   },
-  socialMediaLinks: [
-    {
-      provider: 'twitter',
-      href: 'https://twitter.com/truckerAMT?elqTrack=true',
-      title: 'Follow us on Twitter',
-    },
-    {
-      provider: 'facebook',
-      href: 'https://www.facebook.com/pages/American-Trucker-Magazine/37172697238?elqTrack=true',
-      title: 'Follow us on Facebook',
-    },
-  ],
 };

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -133,7 +133,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trucker/templates/american-trucker-daily.marko
+++ b/tenants/trucker/templates/american-trucker-daily.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/trucker/image/static/newsletters/daily_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/trucker/templates/digital-edition.marko
+++ b/tenants/trucker/templates/digital-edition.marko
@@ -50,7 +50,7 @@ $ const buttonTextStyle = {
 
     <common-section-spacer-element />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>

--- a/tenants/trucker/templates/digital-edition.marko
+++ b/tenants/trucker/templates/digital-edition.marko
@@ -31,8 +31,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/trucker/image/static/newsletters/digital_edition_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/trucker/templates/marketplace.marko
+++ b/tenants/trucker/templates/marketplace.marko
@@ -32,8 +32,9 @@ $ const buttonTextStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
+      teaser=newsletter.teaser
     />
-    <tenant-header-block image-path="/files/base/ebm/trucker/image/static/newsletters/marketplace_header.jpg" date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/trucker/templates/marketplace.marko
+++ b/tenants/trucker/templates/marketplace.marko
@@ -47,7 +47,7 @@ $ const buttonTextStyle = {
       button-text-style=buttonTextStyle
     />
 
-    <common-style-a-opt-out-block />
+    <common-style-a-opt-out-block newsletter=newsletter/>
 
   </@body>
 </marko-newsletter-root>


### PR DESCRIPTION
Relates to: https://github.com/base-cms-newsletters/endeavor-business-media/pull/226
Sets up the config-based fields for the remaining tenants ("style-a" component support).

As I go through each tenant, I'm updating the configs in the database with all the appropriate fields, so the user shouldn't notice a difference when this goes live, besides the fact that they'll now be able to make changes through the interface should they so choose to.  

**Note:** When a new newsletter is created, we'll need to add a config and update the values through the interface instead of the `core.js` file.

### Example of what the interface should look like in comparison to the newsletter:
<img width="822" alt="Screen Shot 2020-09-30 at 1 23 16 PM" src="https://user-images.githubusercontent.com/12496550/94814471-fdb37c00-03be-11eb-8eb5-459a1da5aa6a.png">
<img width="830" alt="Screen Shot 2020-09-30 at 1 19 32 PM" src="https://user-images.githubusercontent.com/12496550/94814482-00ae6c80-03bf-11eb-81e6-7de7213de280.png">


### Note on the header:
Unlike "style-b" tenants, the "style-a" tenants only use one type of header, so they now all pull from one `header.marko` file, instead of having unique individual headers within each tenant folder.  This causes the spacing to be fully consistent, something they don't have now.  I noticed each tenant has a few pixels of difference in their header files, some taller than others, some with padding on the sides of the logo, etc.  This makes them all the same to keep in consistent.

### Example of header for the informa/gemenon/style-a group:
<img width="741" alt="Screen Shot 2020-09-30 at 12 00 33 PM" src="https://user-images.githubusercontent.com/12496550/94814328-ce047400-03be-11eb-992f-f1d6f0ee5c46.png">

### Base configuration values for the above style:
<img width="1036" alt="Screen Shot 2020-09-30 at 12 00 42 PM" src="https://user-images.githubusercontent.com/12496550/94814353-d6f54580-03be-11eb-9742-688257e537bc.png">


### Example of what the header looks like without any colors or logos added through the interface:
![image](https://user-images.githubusercontent.com/12496550/94823661-b8487c00-03c9-11eb-9df5-380e93cf6b51.png)



There were a handful of newsletters that would have a black date and gray description color, with a custom newsletter name color.  (IE = TD World)
<img width="601" alt="Screen Shot 2020-10-06 at 3 56 26 PM" src="https://user-images.githubusercontent.com/12496550/95259888-7bc3b880-07ed-11eb-84d5-9afdd62feaed.png">

I added a check to see if the background color hex includes “#fff” and set the date color and description color to something other than the font color.  For newsletters with colored backgrounds, the date and descriptions are the same color as the newsletter name.

This won’t work if the user sets the background color to “white” or if they do something like ‘#fff322’ but all variations of ‘#fffXXX” are bright yellow, so these color overrides will still look nice.
  