### PR TITLE
Remove field from promotion-full else layout (release before 10/08)

### DIFF
--- a/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
+++ b/packages/common/components/style-a/blocks/special-edition-full-promotion.marko
@@ -79,7 +79,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
     </tr>
     <tr>
       <td style=teaserWrapperStyle style="padding: 0 20px;" >
-        <common-content-teaser-element field=field node=node teaser-style=teaserStyle tag="p" />
+        <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
       </td>
     </tr>
     <if(node.linkText)>


### PR DESCRIPTION
https://newsletters.electronicdesign.com/templates/ed-update?date=1600833600000

<img width="726" alt="Screen Shot 2020-10-05 at 3 42 40 PM" src="https://user-images.githubusercontent.com/6343242/95124430-6c773900-0721-11eb-9345-ecb682e95bbd.png">

This eNL has a deployment scheduled for 10/08