### PR TITLE
Prioritize body before teaser on promotions

### DIFF
--- a/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
+++ b/packages/common/components/style-a/blocks/simple-card-third-two-thirds.marko
@@ -35,7 +35,12 @@ $ const innerPadding = 20;
           <tr>
             <td style=`padding: ${innerPadding}px;`>
               <common-content-link-element node=node content-link-style=contentLinkStyle />
-              <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+              <if(node.type === 'promotion' && node.body)>
+                <common-content-teaser-element node=node teaser-style=teaserStyle field="body" />
+              </if>
+              <else>
+                <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+              </else>
             </td>
           </tr>
           <tr>
@@ -57,7 +62,12 @@ $ const innerPadding = 20;
     <tr>
       <td style=`padding: ${innerPadding}px;`>
         <common-content-link-element node=node content-link-style=contentLinkStyle tag="h3" />
-        <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+        <if(node.type === 'promotion' && node.body)>
+          <common-content-teaser-element node=node teaser-style=teaserStyle field="body" />
+        </if>
+        <else>
+          <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
+        </else>
         <common-section-spacer-element />
         <common-button-element
           button-style=buttonStyle


### PR DESCRIPTION
Relates to: https://github.com/base-cms-newsletters/endeavor-business-media/pull/241

Affects: 
- TDWorld's Lineman's Rodeo: https://newsletters.tdworld.com/templates/international-linemans-rodeo?date=1603166400000
- TD World's Smart Utility: https://newsletters.tdworld.com/templates/smart-utility?date=1603425600000

Per Joe via: https://southcomm.atlassian.net/browse/DEV-289

Technically the `node.type === 'promotion'` bit is unnecessary, since graph only passes `body` on promotions, but this just adds an extra level of clarity.

<img width="577" alt="Screen Shot 2020-10-19 at 10 37 08 AM" src="https://user-images.githubusercontent.com/12496550/96475898-2d091c00-11fa-11eb-82ad-629e2035d7e4.png">
