### PR TITLE
Minor spacing tweaks in style-a simple-card

### DIFF
--- a/packages/common/components/style-a/blocks/simple-card-full.marko
+++ b/packages/common/components/style-a/blocks/simple-card-full.marko
@@ -44,10 +44,7 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
       <td style=`padding: 0; padding-right: ${innerPadding}px;`>
         <common-table width=innerTableWidth style=`border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding:0; margin:0;` align="right" class="right" padding=0 spacing=0>
           <tr>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td style="padding-bottom: 5px;">
+            <td style="padding: 10px 0;">
               <common-content-link-element node=node content-link-style=contentLinkStyle tag="h3" />
             </td>
           </tr>

--- a/packages/common/components/style-a/blocks/simple-card.marko
+++ b/packages/common/components/style-a/blocks/simple-card.marko
@@ -36,8 +36,8 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
           <td>
             <if(displayImage)>
               <common-primary-image-element node=node img-width=imgWidth class-name="main" />
+              <common-section-spacer-element />
             </if>
-            <common-section-spacer-element />
             <common-content-link-element node=node content-link-style=contentLinkStyle tag="h3" />
             <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
             <common-section-spacer-element />


### PR DESCRIPTION
These blocks just had some extra spacing that was bugging me.  It's not a big change, but it makes me happy.  

Simple card full:
<img width="1740" alt="Screen Shot 2020-10-21 at 2 26 42 PM" src="https://user-images.githubusercontent.com/12496550/96776532-c416d500-13ae-11eb-9c2e-17546b3d0c1f.png">

Simple card 2-column, no image:
<img width="1241" alt="Screen Shot 2020-10-21 at 2 55 44 PM" src="https://user-images.githubusercontent.com/12496550/96776567-d09b2d80-13ae-11eb-8e92-dc44c6d4c1e0.png">

I tested these changes on a couple different newsletters and ran them all through emailonacid; didn't find any noticeable disruption in the blocks that are related to this change.