### PR TITLE
Update header template of Solutions Spotlight eNLs

### DIFF
--- a/tenants/americanmachinist/templates/solutions-spotlight.marko
+++ b/tenants/americanmachinist/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/ehstoday/templates/solutions-spotlight.marko
+++ b/tenants/ehstoday/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/foundrymag/templates/solutions-spotlight.marko
+++ b/tenants/foundrymag/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/gxcontractor/templates/solutions-spotlight.marko
+++ b/tenants/gxcontractor/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/newequipment/templates/solutions-spotlight.marko
+++ b/tenants/newequipment/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 

--- a/tenants/plasticsmachinerymagazine/templates/solutions-spotlight.marko
+++ b/tenants/plasticsmachinerymagazine/templates/solutions-spotlight.marko
@@ -31,7 +31,7 @@ $ const buttonTextStyle = {
       date=date
       teaser=newsletter.teaser
     />
-    <common-style-a-header-block date=date newsletter=newsletter />
+    <common-style-b-image-only-header-block date=date newsletter=newsletter />
 
     <common-section-spacer-element />
 


### PR DESCRIPTION
Per Deb, the groups are requesting the standard header template choices instead of the custom Informa override headers.  

<img width="655" alt="Screen Shot 2020-10-28 at 1 37 13 PM" src="https://user-images.githubusercontent.com/12496550/97482430-27ab8000-1924-11eb-8039-658ab4859cb7.png">
<img width="671" alt="Screen Shot 2020-10-28 at 1 37 56 PM" src="https://user-images.githubusercontent.com/12496550/97482431-28441680-1924-11eb-9aa4-70e46562ad13.png">
<img width="629" alt="Screen Shot 2020-10-28 at 1 38 46 PM" src="https://user-images.githubusercontent.com/12496550/97482433-29754380-1924-11eb-832b-35f1eee94650.png">
<img width="657" alt="Screen Shot 2020-10-28 at 1 40 08 PM" src="https://user-images.githubusercontent.com/12496550/97482437-2aa67080-1924-11eb-8a37-e7b5b0f92122.png">
<img width="648" alt="Screen Shot 2020-10-28 at 1 43 46 PM" src="https://user-images.githubusercontent.com/12496550/97482442-2c703400-1924-11eb-912e-e1a474337564.png">
