### PR TITLE
VSP templates ported from SAP

### DIFF
--- a/packages/common/components/style-b/blocks/marko.json
+++ b/packages/common/components/style-b/blocks/marko.json
@@ -171,6 +171,10 @@
     "@sponsored-label": {
       "type": "boolean",
       "default-value": false
+    },
+    "@show-button": {
+      "type" : "boolean",
+      "default-value": true
     }
   },
   "<common-style-b-promo-card-block>": {
@@ -191,7 +195,11 @@
       "type": "number",
       "default-value": 345
     },
-    "@teaser-style": "object"
+    "@teaser-style": "object",
+    "@show-button": {
+      "type" : "boolean",
+      "default-value": true
+    }
   },
   "<common-style-b-psc-card-block>": {
     "template": "./psc-card.marko",
@@ -212,7 +220,11 @@
       "default-value": 345
     },
     "@teaser-style": "object",
-    "@images" : "array"
+    "@images" : "array",
+    "@show-button": {
+      "type" : "boolean",
+      "default-value": true
+    }
   },
   "<common-style-b-full-section-wrapper-block>": {
     "template": "./full-section-wrapper.marko",

--- a/packages/common/components/style-b/blocks/promo-card.marko
+++ b/packages/common/components/style-b/blocks/promo-card.marko
@@ -9,6 +9,7 @@ $ const {
   contentLinkStyle,
   buttonStyle,
   buttonTextStyle,
+  showButton
 } = input;
 
 $ const innerPadding = 20;
@@ -53,11 +54,13 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
                       <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
                     </else>
                     <common-section-spacer-element />
-                    <common-button-element
-                      button-style=buttonStyle
-                      button-text-style=buttonTextStyle
-                      node=node
-                    />
+                    <if(showButton)>
+                      <common-button-element
+                        button-style=buttonStyle
+                        button-text-style=buttonTextStyle
+                        node=node
+                      />
+                    </if>
                   </td>
                 </tr>
               </common-table>
@@ -90,11 +93,13 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
                 <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
               </else>
               <common-section-spacer-element />
-              <common-button-element
-                button-style=buttonStyle
-                button-text-style=buttonTextStyle
-                node=node
-              />
+              <if(showButton)>
+                <common-button-element
+                  button-style=buttonStyle
+                  button-text-style=buttonTextStyle
+                  node=node
+                />
+              </if>
             </td>
           </tr>
         </common-table>

--- a/packages/common/components/style-b/blocks/psc-card.marko
+++ b/packages/common/components/style-b/blocks/psc-card.marko
@@ -8,7 +8,8 @@ $ const {
   teaserStyle,
   contentLinkStyle,
   buttonStyle,
-  buttonTextStyle
+  buttonTextStyle,
+  showButton
 } = input;
 
 $ const innerPadding = 20;
@@ -70,11 +71,13 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
                       <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
                     </else>
                     <common-section-spacer-element />
-                    <common-button-element
-                      button-style=buttonStyle
-                      button-text-style=buttonTextStyle
-                      node=node
-                    />
+                    <if(showButton)>
+                      <common-button-element
+                        button-style=buttonStyle
+                        button-text-style=buttonTextStyle
+                        node=node
+                      />
+                    </if>
                   </td>
                 </tr>
               </common-table>
@@ -95,11 +98,13 @@ $ const innerTableWidth = tableWidth - (innerPadding * 2);
               <common-content-link-element node=node content-link-style=contentLinkStyle />
               <common-content-teaser-element node=node teaser-style=teaserStyle tag="p" />
               <common-section-spacer-element />
-              <common-button-element
-                button-style=buttonStyle
-                button-text-style=buttonTextStyle
-                node=node
-              />
+              <if(showButton)>
+                <common-button-element
+                  button-style=buttonStyle
+                  button-text-style=buttonTextStyle
+                  node=node
+                />
+              </if>
             </td>
           </tr>
         </common-table>

--- a/packages/common/components/style-b/blocks/text-promo-wrapper.marko
+++ b/packages/common/components/style-b/blocks/text-promo-wrapper.marko
@@ -16,6 +16,7 @@ $ const {
   teaserStyle,
   buttonStyle,
   buttonTextStyle,
+  showButton,
   contentLinkStyle
 } = input;
 
@@ -61,6 +62,7 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
                     img-width=imgWidth
+                    show-button=showButton
                   />
                 </if>
                 <else>
@@ -71,6 +73,7 @@ $ const mainTableStyle = defaultValue(input.mainTableStyle, "border-collapse:col
                     button-text-style=buttonTextStyle
                     teaser-style=teaserStyle
                     img-width=imgWidth
+                    show-button=showButton
                   />
                 </else>
               </td>

--- a/tenants/vspc/config/core.js
+++ b/tenants/vspc/config/core.js
@@ -1,1 +1,23 @@
-module.exports = {};
+module.exports = {
+  dpm: {
+    emailx: {
+      enabled: true,
+    },
+    content: {
+      enabled: true,
+    },
+  },
+  brandAcronym: 'VSP',
+  optOut: {
+    address: 'Vehicle Service Pros<br />Endeavor Business Media<br />331 54th Avenue N.<br />Nashville, TN 37209',
+    safeSenders: 'news.southcommmail.com and mail.southcommmail.com',
+    privacyPolicyUrl: 'https://www.endeavorbusinessmedia.com/privacy-policy',
+    phoneNumber: '800-547-7377',
+  },
+  brandNavLinks: [
+    {
+      href: 'https://www.vehicleservicepros.com/',
+      title: 'Home',
+    },
+  ],
+};

--- a/tenants/vspc/templates/abrn-alert.marko
+++ b/tenants/vspc/templates/abrn-alert.marko
@@ -1,0 +1,97 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64922
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Featured - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64923
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #03 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64924
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #04 Latest News - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64925
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style=mainTableStyle
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/abrn-alert.marko
+++ b/tenants/vspc/templates/abrn-alert.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/abrn-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64960
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64961
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64962
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64963
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64964
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64965
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64966
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64967
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64968
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/abrn-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/abrn-mso-alert.marko
+++ b/tenants/vspc/templates/abrn-mso-alert.marko
@@ -1,0 +1,97 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64938
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Featured - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64939
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #03 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64940
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #04 Latest News - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64941
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style=mainTableStyle
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/abrn-mso-alert.marko
+++ b/tenants/vspc/templates/abrn-mso-alert.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/abrn-mso-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-mso-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64978
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64979
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64980
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64981
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64982
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64983
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64984
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64985
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64986
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/abrn-mso-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-mso-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/aftermarket-business-world-alert.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-alert.marko
@@ -1,0 +1,97 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64926
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Featured - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64927
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #03 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64928
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #04 Latest News - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64929
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style=mainTableStyle
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/aftermarket-business-world-alert.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-alert.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64969
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64970
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64971
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64972
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64973
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64974
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64975
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64976
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64977
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64987
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64988
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64989
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64990
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64991
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64992
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64993
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64994
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64995
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
+++ b/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64996
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64997
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64998
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64999
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=65000
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=65001
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=65002
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=65003
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=65004
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
+++ b/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/motor-age-certified-technician-alert.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-alert.marko
@@ -1,0 +1,97 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64934
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Featured - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64935
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #03 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64936
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #04 Latest News - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64937
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style=mainTableStyle
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/motor-age-certified-technician-alert.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-alert.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64951
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64952
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64953
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64954
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64955
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64956
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64957
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64958
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64959
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/motor-age-service-repair-alert.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-alert.marko
@@ -1,0 +1,97 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64930
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Featured - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64931
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #03 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64932
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #04 Latest News - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64933
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style=mainTableStyle
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/motor-age-service-repair-alert.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-alert.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";

--- a/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
@@ -1,0 +1,157 @@
+import emailX from "../config/email-x";
+$ const { newsletter, date } = data;
+
+$ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";
+$ const contentLinkStyle = {
+  "color": "#012559;",
+  "font": "700 18px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const teaserStyle = {
+  "color": "#666666;",
+  "font": "400 13px/18px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+$ const buttonStyle = "font: 400 13px/21px Arial, Helvetica, sans-serif; border-spacing: 0; padding: 10px 15px; table-layout: fixed; background-color: #012559;";
+$ const buttonTextStyle = {
+  "color": "#fff",
+  "font": "700 16px/24px Arial, Helvetica, sans-serif;",
+  "text-decoration": "none !important;"
+};
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-style-b-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #efefef;">
+    <common-table width="740" style="border-collapse:collapse; background-color: #fff;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-banner-element
+            name=newsletter.name
+            date=date
+            teaser=newsletter.teaser
+          />
+
+          <!-- #01 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64942
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <common-style-b-image-only-header-block date=date newsletter=newsletter />
+
+          <common-section-spacer-element />
+
+          <!-- #02 Latest News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64943
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #03 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64944
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #04 - Leaderboard - 1 Column -->
+          <common-style-a-leaderboard-block
+            section-id=64945
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+          />
+
+          <!-- #05 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64946
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #06 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64947
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #07 More News - 2 Column -->
+          <common-style-a-card-section-wrapper-block
+            section-id=64948
+            date=date
+            newsletter=newsletter
+            main-table-style=mainTableStyle
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            fallback-label=true
+          />
+
+          <!-- #08 Sponsored Content - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64949
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            button-style=buttonStyle
+            button-text-style=buttonTextStyle
+            main-table-style=mainTableStyle
+            show-button=true
+          />
+
+          <!-- #09 Latest News Links - 1 Column -->
+          <common-style-b-text-promo-wrapper
+            section-id=64950
+            date=date
+            newsletter=newsletter
+            content-link-style=contentLinkStyle
+            teaser-style=teaserStyle
+            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            show-button=false
+          />
+
+          <common-style-b-footer-nav-block newsletter=newsletter/>
+
+          <common-style-b-opt-out-block newsletter=newsletter />
+
+        </td>
+      </tr>
+    </common-table>
+  </@body>
+</marko-newsletter-root>

--- a/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
@@ -1,4 +1,3 @@
-import emailX from "../config/email-x";
 $ const { newsletter, date } = data;
 
 $ const mainTableStyle ="border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;";


### PR DESCRIPTION
SAP (search auto parts) eNL templates moving to newsletters.vehicleservicepros.com.  The first round of newsletters (commit "New VSP templates transitioning from SAP") all follow this template structure: [https://southcomm-my.sharepoint.com/:x:/g/personal/dcotton_endeavorb2b_com/EYGh2OrqvKtFktC0dvi-nO4By1_TLkjaLLBu21clqppAtQ?e=ydjGz5](https://southcomm-my.sharepoint.com/:x:/g/personal/dcotton_endeavorb2b_com/EYGh2OrqvKtFktC0dvi-nO4By1_TLkjaLLBu21clqppAtQ?e=ydjGz5)

The bottom block of the newsletter ("04 - Latest News") is the same as the "02 Featured" block - turns out the screenshot from their example is just a Promotion with no image and manually-set links in the body.  "Industry News" is the content title in their screenshot, not the block title.  
![Screen-Shot-2020-11-05-at-9 51 20-AM](https://user-images.githubusercontent.com/12496550/98266646-2a275e80-1f50-11eb-8da9-fc23369a15bc.jpg)

The second round of newsletters (commit "Next round of new VSP eNLs") follow this template structure: [https://southcomm-my.sharepoint.com/:x:/g/personal/dcotton_endeavorb2b_com/ES71wV7Oq2hKgYih97U3XQsBRffcWgfjEpMg3TCQEwfdpw?e=IIlhMS](https://southcomm-my.sharepoint.com/:x:/g/personal/dcotton_endeavorb2b_com/ES71wV7Oq2hKgYih97U3XQsBRffcWgfjEpMg3TCQEwfdpw?e=IIlhMS)

Similar to the first one, only with more blocks and a gray background on the bottom block.  

![Untitled-2](https://user-images.githubusercontent.com/12496550/98281502-77143080-1f62-11eb-9c30-ba7bacf7e7e7.jpg)

