### PR TITLE
VSP's Motor Age Serve Repair eNL minor block changes

### DIFF
--- a/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
@@ -144,7 +144,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
@@ -72,6 +72,7 @@ $ const buttonTextStyle = {
             button-text-style=buttonTextStyle
             main-table-style=mainTableStyle
             show-button=true
+            sponsored-label=true
           />
 
           <!-- #04 - Leaderboard - 1 Column -->
@@ -106,6 +107,7 @@ $ const buttonTextStyle = {
             button-text-style=buttonTextStyle
             main-table-style=mainTableStyle
             show-button=true
+            sponsored-label=true
           />
 
           <!-- #07 More News - 2 Column -->
@@ -132,6 +134,7 @@ $ const buttonTextStyle = {
             button-text-style=buttonTextStyle
             main-table-style=mainTableStyle
             show-button=true
+            sponsored-label=true
           />
 
           <!-- #09 Latest News Links - 1 Column -->


### PR DESCRIPTION
Added "Sponsored" label to all the "Sponsored" sections, and removed the block style override on the last block of the template:
![image](https://user-images.githubusercontent.com/12496550/99978370-7a355c00-2d6b-11eb-9dc8-6e0197fd09a1.png)

https://southcomm.atlassian.net/browse/DEV-334