### PR TITLE
VSP eNL block tweaks on SAP templates

### DIFF
--- a/tenants/vspc/templates/abrn-alert.marko
+++ b/tenants/vspc/templates/abrn-alert.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #04 Latest News - 1 Column -->

--- a/tenants/vspc/templates/abrn-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-e-newsletter.marko
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/abrn-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->

--- a/tenants/vspc/templates/abrn-mso-alert.marko
+++ b/tenants/vspc/templates/abrn-mso-alert.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #04 Latest News - 1 Column -->

--- a/tenants/vspc/templates/abrn-mso-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-mso-e-newsletter.marko
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/abrn-mso-e-newsletter.marko
+++ b/tenants/vspc/templates/abrn-mso-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->

--- a/tenants/vspc/templates/aftermarket-business-world-alert.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-alert.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #04 Latest News - 1 Column -->

--- a/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-business-world-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->

--- a/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
+++ b/tenants/vspc/templates/aftermarket-technology-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
+++ b/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
+++ b/tenants/vspc/templates/auto-market-weekly-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->

--- a/tenants/vspc/templates/motor-age-certified-technician-alert.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-alert.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #04 Latest News - 1 Column -->

--- a/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
@@ -141,7 +141,7 @@ $ const buttonTextStyle = {
             newsletter=newsletter
             content-link-style=contentLinkStyle
             teaser-style=teaserStyle
-            main-table-style="background-color: #e7e7e7; border-collapse:collapse; font: 400 13px/21px Arial, Helvetica, sans-serif; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt;"
+            main-table-style=mainTableStyle
             show-button=false
           />
 

--- a/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-certified-technician-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -92,7 +92,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -118,7 +118,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->

--- a/tenants/vspc/templates/motor-age-service-repair-alert.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-alert.marko
@@ -71,7 +71,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #04 Latest News - 1 Column -->

--- a/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
+++ b/tenants/vspc/templates/motor-age-service-repair-e-newsletter.marko
@@ -58,7 +58,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #03 Sponsored Content - 1 Column -->
@@ -93,7 +93,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #06 Sponsored Content - 1 Column -->
@@ -120,7 +120,7 @@ $ const buttonTextStyle = {
             teaser-style=teaserStyle
             button-style=buttonStyle
             button-text-style=buttonTextStyle
-            fallback-label=true
+            fallback-label=false
           />
 
           <!-- #08 Sponsored Content - 1 Column -->
@@ -134,7 +134,6 @@ $ const buttonTextStyle = {
             button-text-style=buttonTextStyle
             main-table-style=mainTableStyle
             show-button=true
-            sponsored-label=true
           />
 
           <!-- #09 Latest News Links - 1 Column -->


### PR DESCRIPTION
Switched labels to be manually added instead of a fallback on all promotions.  Relates to: https://github.com/cygnusb2b/base-platform/pull/4462

<img width="528" alt="Screen Shot 2020-11-24 at 1 02 50 PM" src="https://user-images.githubusercontent.com/12496550/100141805-9236d980-2e58-11eb-895f-1b24b7461284.png">
<img width="614" alt="Screen Shot 2020-11-24 at 1 01 38 PM" src="https://user-images.githubusercontent.com/12496550/100141809-92cf7000-2e58-11eb-958b-d09cc542b40d.png">

Removed table style override on the bottom eNL blocks so it inherits the same mainTableStyle as the rest of the blocks 