### PR TITLE
update base-cms-dependencies  for latest support.

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,8 +10,8 @@
     "test": "yarn lint"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/marko-newsletters-omail": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/americanmachinist/package.json
+++ b/tenants/americanmachinist/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/asumag/package.json
+++ b/tenants/asumag/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/bulktransporter/package.json
+++ b/tenants/bulktransporter/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/contractingbusiness/package.json
+++ b/tenants/contractingbusiness/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/contractormag/package.json
+++ b/tenants/contractormag/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/dentaleconomics/package.json
+++ b/tenants/dentaleconomics/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/distributedenergy/package.json
+++ b/tenants/distributedenergy/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/ecmweb/package.json
+++ b/tenants/ecmweb/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/ehstoday/package.json
+++ b/tenants/ehstoday/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/electricalmarketing/package.json
+++ b/tenants/electricalmarketing/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/electronicdesign/package.json
+++ b/tenants/electronicdesign/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/evaluationengineering/package.json
+++ b/tenants/evaluationengineering/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/ewweb/package.json
+++ b/tenants/ewweb/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/fleetmaintenance/package.json
+++ b/tenants/fleetmaintenance/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/fleetowner/package.json
+++ b/tenants/fleetowner/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/flowcontrolnetwork/package.json
+++ b/tenants/flowcontrolnetwork/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/forgingmagazine/package.json
+++ b/tenants/forgingmagazine/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/foundrymag/package.json
+++ b/tenants/foundrymag/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/gxcontractor/package.json
+++ b/tenants/gxcontractor/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/hpac/package.json
+++ b/tenants/hpac/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/hpnonline/package.json
+++ b/tenants/hpnonline/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/hydraulicspneumatics/package.json
+++ b/tenants/hydraulicspneumatics/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/industryweek/package.json
+++ b/tenants/industryweek/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/machinedesign/package.json
+++ b/tenants/machinedesign/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/mhlnews/package.json
+++ b/tenants/mhlnews/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/mlo-online/package.json
+++ b/tenants/mlo-online/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/mwrf/package.json
+++ b/tenants/mwrf/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/newequipment/package.json
+++ b/tenants/newequipment/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/plasticsmachinerymagazine/package.json
+++ b/tenants/plasticsmachinerymagazine/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/powerelectronics/package.json
+++ b/tenants/powerelectronics/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/processingmagazine/package.json
+++ b/tenants/processingmagazine/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/rdhmag/package.json
+++ b/tenants/rdhmag/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/refrigeratedtransporter/package.json
+++ b/tenants/refrigeratedtransporter/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/rermag/package.json
+++ b/tenants/rermag/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/sourcetoday/package.json
+++ b/tenants/sourcetoday/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/tdworld/package.json
+++ b/tenants/tdworld/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/trailerbodybuilders/package.json
+++ b/tenants/trailerbodybuilders/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/trucker/package.json
+++ b/tenants/trucker/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/tenants/vspc/package.json
+++ b/tenants/vspc/package.json
@@ -12,8 +12,8 @@
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {
-    "@base-cms/marko-core": "^1.38.0",
-    "@base-cms/marko-newsletters": "^1.39.0",
+    "@base-cms/marko-core": "^1.46.1",
+    "@base-cms/marko-newsletters": "^1.47.0",
     "@base-cms/marko-newsletters-email-x": "^1.41.0",
     "@base-cms/newsletter-cli": "^1.37.0",
     "@base-cms/object-path": "^1.37.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,14 +78,14 @@
     marko "~4.20.0"
     yargs "^14.1.0"
 
-"@base-cms/marko-core@^1.38.0":
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-core/-/marko-core-1.38.0.tgz#9f5ea88fa5103ef852296553b56857354c764496"
-  integrity sha512-sFKhIXFeaRrV0oyEdYCVSUJTLGnPHzQeU4hsx/HzfjigSWX+i7EaI7IMtri65PL0NHKWhkHVXlm8rNxqOTI04A==
+"@base-cms/marko-core@^1.46.1":
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-core/-/marko-core-1.46.1.tgz#2c5c545097e2d32b3e509eb50f1dcb18bf95a0c6"
+  integrity sha512-lAQENbGprQjBKDyY2mB2y36YVbf63m68zmeBconzwFfQZuuo0eGO/NdwSG23GKDwVTTR40kEJF/QCQM4Sy5iMQ==
   dependencies:
     "@base-cms/object-path" "^1.37.0"
     "@base-cms/utils" "^1.37.0"
-    "@base-cms/web-common" "^1.37.0"
+    "@base-cms/web-common" "^1.46.1"
     marko "~4.20.0"
     moment "^2.24.0"
     moment-timezone "^0.5.26"
@@ -105,17 +105,17 @@
   resolved "https://registry.yarnpkg.com/@base-cms/marko-newsletters-omail/-/marko-newsletters-omail-1.37.0.tgz#0c613b199a7819d1a5ee21d629ef88db49452885"
   integrity sha512-t9LkO97uKjhRCcPCBI0Yb+i1LswAUaVXzqac8QHYRgJZoNzflzSnz5FQrQMwdFMjmFtyhRGeM3Iu63FY9jETyA==
 
-"@base-cms/marko-newsletters@^1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-newsletters/-/marko-newsletters-1.39.0.tgz#e17e520d850fe007f88fa072f2777d545a8087ba"
-  integrity sha512-GCweTKEYjBUIANT+KEIIxviP607CpJQj2i5pRFULAzU8moXA2ILuIMOD3yptQj+5ee09GWE3aqTXFNEBJk/Gig==
+"@base-cms/marko-newsletters@^1.47.0":
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-newsletters/-/marko-newsletters-1.47.0.tgz#5474e6959b120e2e1a1ebfa880e2a2b28bcec931"
+  integrity sha512-4XQCucLn/nbVduWZE57YtMPbeieVuT3SaMaAKz9AFNTC3BtPJ3rp7ctwbU6v8lR1iUVx5TtdtWAcCrEUnfjWhA==
   dependencies:
     "@base-cms/express-apollo" "^1.37.0"
     "@base-cms/image" "^1.37.0"
     "@base-cms/object-path" "^1.37.0"
     "@base-cms/tenant-context" "^1.37.0"
     "@base-cms/utils" "^1.37.0"
-    "@base-cms/web-common" "^1.37.0"
+    "@base-cms/web-common" "^1.46.1"
     "@godaddy/terminus" "^4.2.0"
     express "^4.17.1"
     graphql "^14.5.4"
@@ -162,10 +162,10 @@
   resolved "https://registry.yarnpkg.com/@base-cms/utils/-/utils-1.37.0.tgz#c2ac887615b9b5007bae6d6fae102bff3662b706"
   integrity sha512-YVNnlziwb/MdSjt8oywqgXmCwmK/7y3V8niF0GxWYggqLPHRqWWI5ZKO/lq3ZaBv6szSxqfNS/b+B3MNfj1h3Q==
 
-"@base-cms/web-common@^1.37.0":
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/@base-cms/web-common/-/web-common-1.37.0.tgz#6da0a7079f0e8a9d8e7679350209510a2791882a"
-  integrity sha512-oP9rs1z97mO97VPYrFuTwxdF+DQmVSa+SNmDIs7AOp5akzerTRAbqvikSPYcJy7ACeI7DE4ulrVeQZfXYJgvlA==
+"@base-cms/web-common@^1.46.1":
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/@base-cms/web-common/-/web-common-1.46.1.tgz#6b865864328b83da09c1031e1979d9636f48d892"
+  integrity sha512-kU9dIbJdBevgfhD45o6e3pFjqrdSxYqWymmF3yG7G0pj91JESBoe26tM7fYVR7NkF4Nmfrwbbga+py9qQ9qkOg==
   dependencies:
     "@base-cms/inflector" "^1.37.0"
     "@base-cms/object-path" "^1.37.0"


### PR DESCRIPTION
 - add link to latest deployment (?date=latest-campaign)
![Screen Shot 2020-11-30 at 11 49 19 AM](https://user-images.githubusercontent.com/3845869/100645306-19c19400-3302-11eb-8e48-91e7383ef72c.png)

 - adds past year/100 deployment list
![Screen Shot 2020-11-30 at 11 47 34 AM](https://user-images.githubusercontent.com/3845869/100645245-06162d80-3302-11eb-80e5-903bb64c758d.png)
